### PR TITLE
Implement minimal game state

### DIFF
--- a/demoinfocs-rs/src/game_state.rs
+++ b/demoinfocs-rs/src/game_state.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+
+use crate::sendtables::entity::Entity;
+
+/// Very small placeholder for a team state.
+#[derive(Clone, Default)]
+pub struct TeamState {
+    pub id: i32,
+    pub score: i32,
+}
+
+/// Minimal representation of a player.
+#[derive(Clone, Default)]
+pub struct Player {
+    pub user_id: i32,
+    pub entity_id: i32,
+    pub name: String,
+    pub team: i32,
+}
+
+#[derive(Clone, Default)]
+pub struct GrenadeProjectile {
+    pub entity_id: i32,
+}
+
+#[derive(Clone, Default)]
+pub struct Inferno {
+    pub entity_id: i32,
+}
+
+#[derive(Clone, Default)]
+pub struct Equipment {
+    pub entity_id: i32,
+}
+
+#[derive(Clone, Default)]
+pub struct Hostage {
+    pub entity_id: i32,
+}
+
+#[derive(Clone, Default)]
+pub struct Bomb {
+    pub entity_id: i32,
+}
+
+/// Holds all connected participants.
+pub struct Participants<'a> {
+    players_by_user_id: &'a HashMap<i32, Player>,
+    players_by_entity_id: &'a HashMap<i32, Player>,
+}
+
+impl<'a> Participants<'a> {
+    pub fn by_user_id(&self) -> HashMap<i32, Player> {
+        self.players_by_user_id.clone()
+    }
+
+    pub fn by_entity_id(&self) -> HashMap<i32, Player> {
+        self.players_by_entity_id.clone()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct GameRules {
+    pub con_vars: HashMap<String, String>,
+}
+
+/// Representation of the current game state. This is a very small subset of the
+/// Go implementation. It only tracks a few basic structures so tests can
+/// compile. Further logic will be added as the parser grows.
+#[derive(Default)]
+pub struct GameState {
+    pub t_state: TeamState,
+    pub ct_state: TeamState,
+
+    pub players_by_user_id: HashMap<i32, Player>,
+    pub players_by_entity_id: HashMap<i32, Player>,
+
+    pub grenade_projectiles: HashMap<i32, GrenadeProjectile>,
+    pub infernos: HashMap<i32, Inferno>,
+    pub weapons: HashMap<i32, Equipment>,
+    pub hostages: HashMap<i32, Hostage>,
+    pub entities: HashMap<i32, Entity>,
+    pub bomb: Bomb,
+
+    pub rules: GameRules,
+}
+
+impl GameState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn participants(&self) -> Participants {
+        Participants {
+            players_by_user_id: &self.players_by_user_id,
+            players_by_entity_id: &self.players_by_entity_id,
+        }
+    }
+
+    pub fn rules(&self) -> &GameRules {
+        &self.rules
+    }
+
+    pub fn handle_event<E>(&mut self, _event: &E) {}
+
+    pub fn handle_net_message<M>(&mut self, _msg: &M) {}
+}

--- a/demoinfocs-rs/src/lib.rs
+++ b/demoinfocs-rs/src/lib.rs
@@ -1,10 +1,11 @@
 pub mod bitreader;
 pub mod dispatcher;
+pub mod events;
+pub mod game_state;
 pub mod parser;
 pub mod proto;
 pub mod sendtables;
 pub mod sendtables2;
-pub mod events;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/demoinfocs-rs/src/proto/msg/mod.rs
+++ b/demoinfocs-rs/src/proto/msg/mod.rs
@@ -1,8 +1,8 @@
-pub mod cstrike15_usermessages;
-pub mod netmessages;
-pub mod cstrike15_gcmessages;
-pub mod engine_gcmessages;
 pub mod steammessages;
+pub mod cstrike15_gcmessages;
+pub mod cstrike15_usermessages;
+pub mod engine_gcmessages;
+pub mod netmessages;
 #[path = "_.rs"]
 pub mod all;
 pub use all::*;

--- a/demoinfocs-rs/src/sendtables2/mod.rs
+++ b/demoinfocs-rs/src/sendtables2/mod.rs
@@ -26,5 +26,7 @@ impl Parser {
         Ok(())
     }
 
-    pub fn class_id_size(&self) -> u32 { self.class_id_size }
+    pub fn class_id_size(&self) -> u32 {
+        self.class_id_size
+    }
 }

--- a/demoinfocs-rs/tests/parser.rs
+++ b/demoinfocs-rs/tests/parser.rs
@@ -6,7 +6,7 @@ use std::thread;
 
 #[test]
 fn test_parser_handlers() {
-    let p = Parser::new(Cursor::new(Vec::<u8>::new()));
+    let mut p = Parser::new(Cursor::new(Vec::<u8>::new()));
     let ev_count = Arc::new(AtomicUsize::new(0));
     let ev_c = ev_count.clone();
     p.register_event_handler::<u8, _>(move |v| {


### PR DESCRIPTION
## Summary
- add placeholder game state implementation
- expose game state from parser and update it when dispatching events
- keep generated proto modules accessible by updating build script
- adjust tests for new parser API

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686614db40e08326a9601f82441a2d57