### PR TITLE
Fix prost-build include path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ cargo build --manifest-path demoinfocs-rs/Cargo.toml
 
 This builds the library and all examples.
 
+### Requirements
+
+The build script compiles several protocol buffer files using `protoc`.
+Install the protobuf compiler before building. On Debian/Ubuntu systems:
+
+```bash
+sudo apt-get install protobuf-compiler libprotobuf-dev
+```
+
+If `PROTOC_INCLUDE` is set, the build script will use it to locate
+`google/protobuf/descriptor.proto`. When `prost-build` is built with its
+bundled `protoc`, this variable is provided automatically.
+
 ## Testing
 
 Run the tests with:

--- a/demoinfocs-rs/build.rs
+++ b/demoinfocs-rs/build.rs
@@ -66,7 +66,11 @@ fn compile(input: &str, output: &str) -> Result<(), Box<dyn std::error::Error>> 
     std::fs::write(out_dir.join("mod.rs"), mod_rs)?;
     let mut config = prost_build::Config::new();
     config.out_dir(&out_dir);
-    config.compile_protos(&protos, &[in_dir.as_path(), Path::new("/usr/include")])?;
+    let mut includes: Vec<PathBuf> = vec![in_dir.clone()];
+    if let Ok(protoc_include) = std::env::var("PROTOC_INCLUDE") {
+        includes.push(PathBuf::from(protoc_include));
+    }
+    config.compile_protos(&protos, &includes)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- update build script to use PROTOC_INCLUDE if set
- document protobuf compiler requirement in README

## Testing
- `cargo fmt -- --check`
- `cargo clippy` *(fails: could not compile `demoinfocs-rs`)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(failed to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6866448f93a48326a77aacefd6a12f5f