### PR TITLE
Port player helpers

### DIFF
--- a/demoinfocs-rs/src/common/player.rs
+++ b/demoinfocs-rs/src/common/player.rs
@@ -1,4 +1,5 @@
-use super::Equipment;
+use super::{Equipment, EquipmentType};
+use crate::constants;
 use crate::sendtables::entity::{Entity, Vector};
 use std::collections::HashMap;
 
@@ -9,6 +10,23 @@ pub enum Team {
     Spectators = 1,
     Terrorists = 2,
     CounterTerrorists = 3,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum Color {
+    Grey = -1,
+    Yellow = 0,
+    Purple = 1,
+    Green = 2,
+    Blue = 3,
+    Orange = 4,
+}
+
+impl Default for Color {
+    fn default() -> Self {
+        Color::Grey
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -31,4 +49,114 @@ pub struct Player {
     pub is_reloading: bool,
     pub is_unknown: bool,
     pub previous_frame_position: Vector,
+}
+
+impl Player {
+    pub fn ping(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_iPing"))
+            .map(|v| {
+                if v.int_val != 0 {
+                    v.int_val
+                } else {
+                    v.int64_val as i32
+                }
+            })
+            .unwrap_or(0)
+    }
+
+    pub fn score(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_iScore"))
+            .map(|v| v.int_val)
+            .unwrap_or(0)
+    }
+
+    pub fn health(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_iHealth"))
+            .map(|v| v.int_val)
+            .unwrap_or(0)
+    }
+
+    pub fn is_alive(&self) -> bool {
+        if self.health() > 0 {
+            return true;
+        }
+        if let Some(ent) = &self.entity {
+            if let Some(v) = ent.property_value("m_lifeState") {
+                return v.int_val == 0;
+            }
+            if let Some(v) = ent.property_value("m_bPawnIsAlive") {
+                return v.bool_val();
+            }
+        }
+        false
+    }
+
+    fn active_weapon_id(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_hActiveWeapon"))
+            .map(|v| v.int_val & constants::ENTITY_HANDLE_INDEX_MASK as i32)
+            .unwrap_or(0)
+    }
+
+    pub fn active_weapon(&self) -> Option<&Equipment> {
+        let id = self.active_weapon_id();
+        self.inventory.get(&id)
+    }
+
+    pub fn weapons(&self) -> Vec<&Equipment> {
+        self.inventory.values().collect()
+    }
+
+    pub fn equipment_value_current(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_unCurrentEquipmentValue"))
+            .map(|v| v.int_val)
+            .unwrap_or(0)
+    }
+
+    pub fn equipment_value_round_start(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_unRoundStartEquipmentValue"))
+            .map(|v| v.int_val)
+            .unwrap_or(0)
+    }
+
+    pub fn equipment_value_freezetime_end(&self) -> i32 {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_unFreezetimeEndEquipmentValue"))
+            .map(|v| v.int_val)
+            .unwrap_or(0)
+    }
+
+    pub fn has_defuse_kit(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| {
+                e.property_value("m_pItemServices.m_bHasDefuser")
+                    .or_else(|| e.property_value("m_bHasDefuser"))
+            })
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn has_helmet(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| {
+                e.property_value("m_pItemServices.m_bHasHelmet")
+                    .or_else(|| e.property_value("m_bHasHelmet"))
+            })
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
 }

--- a/demoinfocs-rs/tests/player.rs
+++ b/demoinfocs-rs/tests/player.rs
@@ -1,0 +1,65 @@
+use demoinfocs_rs::common::{Equipment, EquipmentType, Player, Team};
+use demoinfocs_rs::constants;
+use demoinfocs_rs::sendtables::entity::{
+    Entity, FlattenedPropEntry, Property, PropertyValue, Vector,
+};
+use demoinfocs_rs::sendtables::propdecoder::SendTableProperty;
+use demoinfocs_rs::sendtables::serverclass::ServerClass;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+fn make_entity(props: Vec<(&str, i32)>) -> Entity {
+    let sc = Rc::new(ServerClass::default());
+    let props_vec = props
+        .iter()
+        .map(|(name, val)| Property {
+            entry: FlattenedPropEntry {
+                name: name.to_string(),
+                prop: SendTableProperty::default(),
+                array_element_prop: None,
+            },
+            value: PropertyValue {
+                int_val: *val,
+                ..Default::default()
+            },
+        })
+        .collect::<Vec<_>>();
+    Entity {
+        id: 0,
+        serial_num: 0,
+        server_class: sc,
+        props: props_vec,
+    }
+}
+
+#[test]
+fn ping_score_alive() {
+    let ent = make_entity(vec![("m_iPing", 55), ("m_iScore", 3), ("m_iHealth", 10)]);
+    let p = Player {
+        entity: Some(ent),
+        ..Default::default()
+    };
+    assert_eq!(55, p.ping());
+    assert_eq!(3, p.score());
+    assert!(p.is_alive());
+}
+
+#[test]
+fn active_weapon_and_weapons() {
+    let mut inv = HashMap::new();
+    inv.insert(
+        1,
+        Equipment {
+            equipment_type: EquipmentType::Ak47,
+            ..Default::default()
+        },
+    );
+    let ent = make_entity(vec![("m_hActiveWeapon", 1)]);
+    let p = Player {
+        inventory: inv,
+        entity: Some(ent),
+        ..Default::default()
+    };
+    assert!(p.active_weapon().is_some());
+    assert_eq!(1, p.weapons().len());
+}


### PR DESCRIPTION
## Summary
- add player color enum and helper methods
- translate ping/score/is_alive and equipment helpers
- test player helper functions

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml` *(fails: protoc missing)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: protoc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866476fe0648326b00bfa7a71a4b189