### PR TITLE
Add basic game state structures

### DIFF
--- a/demoinfocs-rs/src/common/bomb.rs
+++ b/demoinfocs-rs/src/common/bomb.rs
@@ -1,0 +1,18 @@
+use super::Player;
+use crate::sendtables::entity::Vector;
+
+#[derive(Debug, Clone, Default)]
+pub struct Bomb {
+    pub last_on_ground_position: Vector,
+    pub carrier: Option<Player>,
+}
+
+impl Bomb {
+    pub fn position(&self) -> Vector {
+        if let Some(carrier) = &self.carrier {
+            carrier.position()
+        } else {
+            self.last_on_ground_position
+        }
+    }
+}

--- a/demoinfocs-rs/src/common/grenade.rs
+++ b/demoinfocs-rs/src/common/grenade.rs
@@ -19,3 +19,14 @@ pub struct GrenadeProjectile {
     pub trajectory2: Vec<TrajectoryEntry>,
     pub unique_id: i64,
 }
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+static NEXT_ID: AtomicI64 = AtomicI64::new(1);
+
+pub fn new_grenade_projectile() -> GrenadeProjectile {
+    GrenadeProjectile {
+        unique_id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+        ..Default::default()
+    }
+}

--- a/demoinfocs-rs/src/common/mod.rs
+++ b/demoinfocs-rs/src/common/mod.rs
@@ -2,10 +2,12 @@
 
 mod equipment;
 mod grenade;
+mod bomb;
 mod hostage;
 mod player;
 
 pub use equipment::*;
 pub use grenade::*;
 pub use hostage::*;
+pub use bomb::*;
 pub use player::*;

--- a/demoinfocs-rs/src/common/player.rs
+++ b/demoinfocs-rs/src/common/player.rs
@@ -32,3 +32,12 @@ pub struct Player {
     pub is_unknown: bool,
     pub previous_frame_position: Vector,
 }
+
+impl Player {
+    pub fn position(&self) -> Vector {
+        self.entity
+            .as_ref()
+            .and_then(|_| Some(self.last_alive_position))
+            .unwrap_or(self.last_alive_position)
+    }
+}

--- a/demoinfocs-rs/src/game_state.rs
+++ b/demoinfocs-rs/src/game_state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::sendtables::entity::Entity;
+use crate::common::{Bomb, Equipment, GrenadeProjectile, Hostage, Inferno, Player};
 
 /// Very small placeholder for a team state.
 #[derive(Clone, Default)]
@@ -9,39 +10,6 @@ pub struct TeamState {
     pub score: i32,
 }
 
-/// Minimal representation of a player.
-#[derive(Clone, Default)]
-pub struct Player {
-    pub user_id: i32,
-    pub entity_id: i32,
-    pub name: String,
-    pub team: i32,
-}
-
-#[derive(Clone, Default)]
-pub struct GrenadeProjectile {
-    pub entity_id: i32,
-}
-
-#[derive(Clone, Default)]
-pub struct Inferno {
-    pub entity_id: i32,
-}
-
-#[derive(Clone, Default)]
-pub struct Equipment {
-    pub entity_id: i32,
-}
-
-#[derive(Clone, Default)]
-pub struct Hostage {
-    pub entity_id: i32,
-}
-
-#[derive(Clone, Default)]
-pub struct Bomb {
-    pub entity_id: i32,
-}
 
 /// Holds all connected participants.
 pub struct Participants<'a> {
@@ -69,6 +37,7 @@ pub struct GameRules {
 /// compile. Further logic will be added as the parser grows.
 #[derive(Default)]
 pub struct GameState {
+    pub ingame_tick: i32,
     pub t_state: TeamState,
     pub ct_state: TeamState,
 
@@ -101,7 +70,22 @@ impl GameState {
         &self.rules
     }
 
-    pub fn handle_event<E>(&mut self, _event: &E) {}
+    pub fn ingame_tick(&self) -> i32 {
+        self.ingame_tick
+    }
+
+    pub fn set_ingame_tick(&mut self, tick: i32) {
+        self.ingame_tick = tick;
+    }
+
+    pub fn handle_event<E: 'static>(&mut self, event: &E) {
+        let any = event as &dyn std::any::Any;
+        if let Some(cv) = any.downcast_ref::<crate::events::ConVarsUpdated>() {
+            for (k, v) in &cv.updated_con_vars {
+                self.rules.con_vars.insert(k.clone(), v.clone());
+            }
+        }
+    }
 
     pub fn handle_net_message<M>(&mut self, _msg: &M) {}
 }

--- a/demoinfocs-rs/tests/common_bomb.rs
+++ b/demoinfocs-rs/tests/common_bomb.rs
@@ -1,0 +1,13 @@
+use demoinfocs_rs::common::{Bomb, Player};
+use demoinfocs_rs::sendtables::entity::Vector;
+
+#[test]
+fn bomb_position() {
+    let mut bomb = Bomb::default();
+    bomb.last_on_ground_position = Vector { x: 1.0, y: 2.0, z: 3.0 };
+    assert_eq!(bomb.position(), Vector { x: 1.0, y: 2.0, z: 3.0 });
+
+    let carrier = Player { last_alive_position: Vector { x: 4.0, y: 5.0, z: 6.0 }, ..Default::default() };
+    bomb.carrier = Some(carrier.clone());
+    assert_eq!(bomb.position(), carrier.position());
+}

--- a/demoinfocs-rs/tests/common_grenade.rs
+++ b/demoinfocs-rs/tests/common_grenade.rs
@@ -1,0 +1,8 @@
+use demoinfocs_rs::common::new_grenade_projectile;
+
+#[test]
+fn grenade_projectile_unique_id() {
+    let a = new_grenade_projectile();
+    let b = new_grenade_projectile();
+    assert_ne!(a.unique_id, b.unique_id);
+}


### PR DESCRIPTION
## Summary
- add a Bomb struct and helper functions
- expose grenade projectile helper and player position helper
- track in-game tick and CVars in GameState
- include simple unit tests for bomb and grenade helpers

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml` *(fails: RoundEnd defined multiple times)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68664766ccc0832680f9a5a1f0105402