### PR TITLE
Implement equipment mapping from server classes

### DIFF
--- a/demoinfocs-rs/src/common/equipment.rs
+++ b/demoinfocs-rs/src/common/equipment.rs
@@ -185,3 +185,73 @@ pub struct Equipment {
     pub unique_id: i64,
     pub position: Vector,
 }
+
+/// Maps a weapon or equipment name to [`EquipmentType`].
+pub fn map_equipment(name: &str) -> EquipmentType {
+    let mut n = name.to_lowercase();
+    if let Some(stripped) = n.strip_prefix("weapon_") {
+        n = stripped.to_string();
+    }
+
+    if n.contains("knife") || n.contains("bayonet") {
+        return EquipmentType::Knife;
+    }
+
+    match n.as_str() {
+        | "ak47" => EquipmentType::Ak47,
+        | "aug" => EquipmentType::Aug,
+        | "awp" => EquipmentType::Awp,
+        | "bizon" => EquipmentType::Bizon,
+        | "c4" | "planted_c4" => EquipmentType::Bomb,
+        | "deagle" => EquipmentType::Deagle,
+        | "decoy" | "decoygrenade" | "decoyprojectile" | "decoy_projectile" => EquipmentType::Decoy,
+        | "elite" => EquipmentType::DualBerettas,
+        | "famas" => EquipmentType::Famas,
+        | "fiveseven" => EquipmentType::FiveSeven,
+        | "flashbang" => EquipmentType::Flash,
+        | "g3sg1" => EquipmentType::G3Sg1,
+        | "galil" | "galilar" => EquipmentType::Galil,
+        | "glock" => EquipmentType::Glock,
+        | "hegrenade" => EquipmentType::He,
+        | "hkp2000" => EquipmentType::P2000,
+        | "incgrenade" | "incendiarygrenade" => EquipmentType::Incendiary,
+        | "m249" => EquipmentType::M249,
+        | "m4a1" => EquipmentType::M4A4,
+        | "mac10" => EquipmentType::Mac10,
+        | "mag7" => EquipmentType::Swag7,
+        | "molotov" | "molotovgrenade" | "molotovprojectile" | "molotov_projectile" => {
+            EquipmentType::Molotov
+        },
+        | "mp7" => EquipmentType::Mp7,
+        | "mp5sd" => EquipmentType::Mp5,
+        | "mp9" => EquipmentType::Mp9,
+        | "negev" => EquipmentType::Negev,
+        | "nova" => EquipmentType::Nova,
+        | "p250" => EquipmentType::P250,
+        | "p90" => EquipmentType::P90,
+        | "sawedoff" => EquipmentType::SawedOff,
+        | "scar20" => EquipmentType::Scar20,
+        | "sg556" => EquipmentType::Sg556,
+        | "smokegrenade" | "smokegrenadeprojectile" | "smokegrenade_projectile" => {
+            EquipmentType::Smoke
+        },
+        | "ssg08" => EquipmentType::Scout,
+        | "taser" => EquipmentType::Zeus,
+        | "tec9" => EquipmentType::Tec9,
+        | "ump45" => EquipmentType::Ump45,
+        | "xm1014" => EquipmentType::Xm1014,
+        | "m4a1_silencer" | "m4a1_silencer_off" => EquipmentType::M4A1,
+        | "cz75a" => EquipmentType::Cz75,
+        | "usp" | "usp_silencer" | "usp_silencer_off" => EquipmentType::Usp,
+        | "world" | "worldspawn" => EquipmentType::World,
+        | "inferno" => EquipmentType::Incendiary,
+        | "revolver" => EquipmentType::Revolver,
+        | "vest" => EquipmentType::Kevlar,
+        | "vesthelm" => EquipmentType::Helmet,
+        | "defuser" => EquipmentType::DefuseKit,
+        | "scar17" | "sensorgrenade" | "mp5navy" | "p228" | "scout" | "sg550" | "sg552" | "tmp" => {
+            EquipmentType::Unknown
+        },
+        | _ => EquipmentType::Unknown,
+    }
+}

--- a/demoinfocs-rs/src/game_state.rs
+++ b/demoinfocs-rs/src/game_state.rs
@@ -82,6 +82,8 @@ pub struct GameState {
     pub entities: HashMap<i32, Entity>,
     pub bomb: Bomb,
 
+    pub equipment_mapping: HashMap<String, crate::common::EquipmentType>,
+
     pub rules: GameRules,
 }
 

--- a/demoinfocs-rs/src/parser/datatable.rs
+++ b/demoinfocs-rs/src/parser/datatable.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use crate::common::{EquipmentType, map_equipment};
+use crate::sendtables::serverclass::ServerClass;
+
+/// Build a mapping from server class names to [`EquipmentType`].
+pub fn build_equipment_mapping(classes: &[ServerClass]) -> HashMap<String, EquipmentType> {
+    let mut out = HashMap::new();
+    for sc in classes {
+        let name = sc.name.clone();
+        if name == "CC4" {
+            out.insert(name, EquipmentType::Bomb);
+            continue;
+        }
+        if name == "CKnife" {
+            out.insert(name, EquipmentType::Knife);
+            continue;
+        }
+        if name.starts_with("CWeapon") {
+            let eq = map_equipment(&name[7..]);
+            out.insert(name, eq);
+            continue;
+        }
+        let dt = sc.data_table_name.as_str();
+        if dt.starts_with("DT_Weapon") {
+            let eq = map_equipment(&dt[9..]);
+            out.insert(name, eq);
+        } else if dt.starts_with("DT_") {
+            let eq = map_equipment(&dt[3..]);
+            if eq != EquipmentType::Unknown {
+                out.insert(name, eq);
+            }
+        }
+    }
+    out
+}

--- a/demoinfocs-rs/tests/equipment.rs
+++ b/demoinfocs-rs/tests/equipment.rs
@@ -1,0 +1,45 @@
+use demoinfocs_rs::common::{EquipmentType, map_equipment};
+use demoinfocs_rs::parser::datatable::build_equipment_mapping;
+use demoinfocs_rs::sendtables::serverclass::ServerClass;
+
+#[test]
+fn test_map_equipment_basic() {
+    assert_eq!(EquipmentType::Ak47, map_equipment("weapon_ak47"));
+    assert_eq!(
+        EquipmentType::Knife,
+        map_equipment("weapon_knife_butterfly")
+    );
+    assert_eq!(EquipmentType::Unknown, map_equipment("foobar"));
+}
+
+#[test]
+fn test_build_equipment_mapping() {
+    let sc1 = ServerClass {
+        id: 1,
+        name: "CC4".into(),
+        data_table_id: 0,
+        data_table_name: "DT_PlantedC4".into(),
+        ..Default::default()
+    };
+    let sc2 = ServerClass {
+        id: 2,
+        name: "CWeaponAK47".into(),
+        data_table_id: 0,
+        data_table_name: "DT_WeaponAK47".into(),
+        ..Default::default()
+    };
+    let sc3 = ServerClass {
+        id: 3,
+        name: "CSmokeGrenadeProjectile".into(),
+        data_table_id: 0,
+        data_table_name: "DT_SmokeGrenadeProjectile".into(),
+        ..Default::default()
+    };
+    let map = build_equipment_mapping(&[sc1, sc2, sc3]);
+    assert_eq!(Some(&EquipmentType::Bomb), map.get("CC4"));
+    assert_eq!(Some(&EquipmentType::Ak47), map.get("CWeaponAK47"));
+    assert_eq!(
+        Some(&EquipmentType::Smoke),
+        map.get("CSmokeGrenadeProjectile")
+    );
+}


### PR DESCRIPTION
## Summary
- add `map_equipment` helper for string->`EquipmentType`
- parse datatables into equipment mappings
- expose mapping in `GameState`
- unit test equipment mapping logic

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml` *(fails: protoc missing)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: protoc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866477d15b88326aea781e0cb15e5d0