### PR TITLE
Add SteamID conversion utilities

### DIFF
--- a/demoinfocs-rs/src/lib.rs
+++ b/demoinfocs-rs/src/lib.rs
@@ -9,6 +9,7 @@ pub mod parser;
 pub mod proto;
 pub mod sendtables;
 pub mod sendtables2;
+pub mod utils;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/demoinfocs-rs/src/utils/mod.rs
+++ b/demoinfocs-rs/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod steamid;
+
+pub use steamid::*;

--- a/demoinfocs-rs/src/utils/steamid.rs
+++ b/demoinfocs-rs/src/utils/steamid.rs
@@ -1,0 +1,68 @@
+use std::num::ParseIntError;
+
+/// Error type returned by SteamID conversion functions.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SteamIdError {
+    /// The given string does not follow the expected `STEAM_X:Y:Z` format.
+    InvalidFormat,
+    /// An integer component of the SteamID could not be parsed.
+    ParseError(ParseIntError),
+}
+
+/// Converts a textual SteamID (e.g. `STEAM_0:1:26343269`) into a 32-bit variant.
+///
+/// Returns [`SteamIdError`] if the input is not well formed or cannot be parsed.
+pub fn convert_steam_id_txt_to_32(steam_id: &str) -> Result<u32, SteamIdError> {
+    let trimmed = steam_id.trim_end_matches(']');
+    let parts: Vec<&str> = trimmed.split(':').collect();
+    if parts.len() != 3 {
+        return Err(SteamIdError::InvalidFormat);
+    }
+
+    let y = parts[1].parse::<u32>().map_err(SteamIdError::ParseError)?;
+    let z = parts[2].parse::<u32>().map_err(SteamIdError::ParseError)?;
+
+    Ok((z << 1) + y)
+}
+
+const STEAM_ID64_INDIVIDUAL_IDENTIFIER: u64 = 0x0110_0001_0000_0000;
+
+/// Converts a 32-bit SteamID to the 64-bit variant.
+pub fn convert_steam_id32_to_64(steam_id32: u32) -> u64 {
+    STEAM_ID64_INDIVIDUAL_IDENTIFIER + steam_id32 as u64
+}
+
+/// Converts a 64-bit SteamID to the 32-bit variant.
+pub fn convert_steam_id64_to_32(steam_id64: u64) -> u32 {
+    (steam_id64 - STEAM_ID64_INDIVIDUAL_IDENTIFIER) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_txt_to_32() {
+        let id = convert_steam_id_txt_to_32("STEAM_0:1:26343269").unwrap();
+        assert_eq!(52686539, id);
+    }
+
+    #[test]
+    fn test_convert_txt_to_32_error() {
+        assert!(convert_steam_id_txt_to_32("STEAM_0:1:a").is_err());
+        assert!(convert_steam_id_txt_to_32("STEAM_0:b:21643603").is_err());
+        assert!(convert_steam_id_txt_to_32("STEAM_0:b").is_err());
+    }
+
+    #[test]
+    fn test_convert_32_to_64() {
+        let id = convert_steam_id32_to_64(52686539);
+        assert_eq!(76561198012952267u64, id);
+    }
+
+    #[test]
+    fn test_convert_64_to_32() {
+        let id = convert_steam_id64_to_32(76561198012952267u64);
+        assert_eq!(52686539u32, id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement text/32/64 SteamID conversions
- expose `utils::steamid` module
- add tests

## Testing
- `cargo fmt -- --check` *(fails: unstable options and unformatted generated files)*
- `cargo clippy` *(fails: protoc missing)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: protoc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866477f783883269c2cd2c43f976a6d