### PR TITLE
Improve README demo setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ If `PROTOC_INCLUDE` is set, the build script will use it to locate
 `google/protobuf/descriptor.proto`. When `prost-build` is built with its
 bundled `protoc`, this variable is provided automatically.
 
+### Demo files
+
+The test suite expects a collection of Counter-Strike demo files located in the
+`demos-external` submodule. Fetch them with:
+
+```bash
+git submodule update --init
+```
+
+If you don't want to download the demos, set the environment variable
+`DEMOINFOCS_SKIP_DEMOS=1` before building or running the tests. The build script
+also understands `FETCH_LATEST_DEMOS=1` to download any missing archives.
+
 ## Testing
 
 Run the tests with:

--- a/demoinfocs-rs/README.md
+++ b/demoinfocs-rs/README.md
@@ -10,6 +10,15 @@ Use Cargo to build the crate from within this directory:
 cargo build
 ```
 
+### Requirements
+
+The build script requires `protoc` to generate Rust types from the protocol
+buffer definitions. Install it via your package manager, e.g. on Debian/Ubuntu:
+
+```bash
+sudo apt-get install protobuf-compiler
+```
+
 ## Examples
 
 Several small examples are available under `examples/`. To run one of them, supply the demo path via the `-demo` flag. For example:
@@ -20,9 +29,15 @@ cargo run --example print_events -- -demo /path/to/demo.dem
 
 ## Tests
 
-Run the unit tests with:
+Run the unit tests from the repository root with:
 
 ```bash
-cargo test
+cargo test --manifest-path demoinfocs-rs/Cargo.toml
 ```
+
+### Demo files
+
+Tests make use of demo files provided through the `demos-external` submodule.
+Fetch them with `git submodule update --init` or set
+`DEMOINFOCS_SKIP_DEMOS=1` to skip demo setup.
 


### PR DESCRIPTION
## Summary
- document fetching demo archives or skipping demo setup via `DEMOINFOCS_SKIP_DEMOS`
- note `protoc` requirement in crate README
- mention running tests with `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `DEMOINFOCS_SKIP_PROTO=1 DEMOINFOCS_SKIP_DEMOS=1 cargo clippy --manifest-path demoinfocs-rs/Cargo.toml` *(fails: could not compile `demoinfocs-rs`)*
- `DEMOINFOCS_SKIP_PROTO=1 DEMOINFOCS_SKIP_DEMOS=1 cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: could not compile `demoinfocs-rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68664aedf4f4832698d32073401ee174