### PR TITLE
Fix duplicated imports and struct fields

### DIFF
--- a/demoinfocs-rs/src/common/equipment.rs
+++ b/demoinfocs-rs/src/common/equipment.rs
@@ -39,7 +39,6 @@ pub enum EquipmentType {
     SawedOff = 201,
     Nova = 202,
     Mag7 = 203,
-    Swag7 = 203,
     Xm1014 = 204,
     M249 = 205,
     Negev = 206,
@@ -50,9 +49,7 @@ pub enum EquipmentType {
     M4A4 = 304,
     M4A1 = 305,
     Scout = 306,
-    Ssg08 = 306,
     Sg556 = 307,
-    Sg553 = 307,
     Aug = 308,
     Awp = 309,
     Scar20 = 310,
@@ -116,7 +113,7 @@ impl EquipmentType {
             | EquipmentType::Mp5 => "MP5-SD",
             | EquipmentType::SawedOff => "Sawed-Off",
             | EquipmentType::Nova => "Nova",
-            | EquipmentType::Mag7 | EquipmentType::Swag7 => "MAG-7",
+            | EquipmentType::Mag7 => "MAG-7",
             | EquipmentType::Xm1014 => "XM1014",
             | EquipmentType::M249 => "M249",
             | EquipmentType::Negev => "Negev",
@@ -125,8 +122,8 @@ impl EquipmentType {
             | EquipmentType::Ak47 => "AK-47",
             | EquipmentType::M4A4 => "M4A4",
             | EquipmentType::M4A1 => "M4A1",
-            | EquipmentType::Scout | EquipmentType::Ssg08 => "SSG 08",
-            | EquipmentType::Sg556 | EquipmentType::Sg553 => "SG 553",
+            | EquipmentType::Scout => "SSG 08",
+            | EquipmentType::Sg556 => "SG 553",
             | EquipmentType::Aug => "AUG",
             | EquipmentType::Awp => "AWP",
             | EquipmentType::Scar20 => "SCAR-20",
@@ -160,6 +157,12 @@ impl EquipmentType {
             | EquipmentType::He => "HE Grenade",
             | EquipmentType::Unknown => "UNKNOWN",
         }
+    }
+}
+
+impl Default for EquipmentType {
+    fn default() -> Self {
+        EquipmentType::Unknown
     }
 }
 
@@ -218,7 +221,7 @@ pub fn map_equipment(name: &str) -> EquipmentType {
         | "m249" => EquipmentType::M249,
         | "m4a1" => EquipmentType::M4A4,
         | "mac10" => EquipmentType::Mac10,
-        | "mag7" => EquipmentType::Swag7,
+        | "mag7" => EquipmentType::Mag7,
         | "molotov" | "molotovgrenade" | "molotovprojectile" | "molotov_projectile" => {
             EquipmentType::Molotov
         },

--- a/demoinfocs-rs/src/common/player.rs
+++ b/demoinfocs-rs/src/common/player.rs
@@ -1,4 +1,4 @@
-use super::{Equipment, EquipmentType};
+use super::Equipment;
 use crate::constants;
 use crate::sendtables::entity::{Entity, Vector};
 use std::collections::HashMap;
@@ -10,6 +10,12 @@ pub enum Team {
     Spectators = 1,
     Terrorists = 2,
     CounterTerrorists = 3,
+}
+
+impl Default for Team {
+    fn default() -> Self {
+        Team::Unassigned
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -537,9 +537,6 @@ pub struct ItemRefund {
 }
 
 #[derive(Clone, Debug)]
-pub struct RoundEnd;
-
-#[derive(Clone, Debug)]
 pub struct DataTablesParsed;
 
 pub struct TeamClanNameUpdated {

--- a/demoinfocs-rs/src/game_events.rs
+++ b/demoinfocs-rs/src/game_events.rs
@@ -31,7 +31,15 @@ impl GameEventHandler {
         }
     }
 
-    pub fn handle_game_event<R: Read>(&self, parser: &Parser<R>, event: &msg::CsvcMsgGameEvent) {
+    pub fn descriptor_name(&self, id: i32) -> Option<&str> {
+        self.descriptors.get(&id).map(|d| d.name.as_str())
+    }
+
+    pub fn handle_game_event<R: Read>(
+        &self,
+        parser: &mut Parser<R>,
+        event: &msg::CsvcMsgGameEvent,
+    ) {
         let id = match event.eventid {
             | Some(v) => v,
             | None => return,
@@ -43,8 +51,18 @@ impl GameEventHandler {
 
         match desc.name.as_str() {
             | "begin_new_match" => parser.dispatch_event(events::MatchStart),
-            | "round_start" => parser.dispatch_event(events::RoundStart),
-            | "round_end" => parser.dispatch_event(events::RoundEnd),
+            | "round_start" => parser.dispatch_event(events::RoundStart {
+                time_limit: 0,
+                frag_limit: 0,
+                objective: String::new(),
+            }),
+            | "round_end" => parser.dispatch_event(events::RoundEnd {
+                message: String::new(),
+                reason: events::RoundEndReason::StillInProgress,
+                winner: 0,
+                winner_state: None,
+                loser_state: None,
+            }),
             | _ => {},
         }
     }

--- a/demoinfocs-rs/src/game_state.rs
+++ b/demoinfocs-rs/src/game_state.rs
@@ -72,6 +72,8 @@ pub struct GameState {
     pub t_state: TeamState,
     pub ct_state: TeamState,
 
+    pub ingame_tick: i32,
+
     pub players_by_user_id: HashMap<i32, Player>,
     pub players_by_entity_id: HashMap<i32, Player>,
 
@@ -106,4 +108,8 @@ impl GameState {
     pub fn handle_event<E>(&mut self, _event: &E) {}
 
     pub fn handle_net_message<M>(&mut self, _msg: &M) {}
+
+    pub fn set_ingame_tick(&mut self, tick: i32) {
+        self.ingame_tick = tick;
+    }
 }

--- a/demoinfocs-rs/src/sendtables/entity.rs
+++ b/demoinfocs-rs/src/sendtables/entity.rs
@@ -23,14 +23,14 @@ impl PropertyValue {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct FlattenedPropEntry {
     pub prop: SendTableProperty,
     pub array_element_prop: Option<SendTableProperty>,
     pub name: String,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Property {
     pub entry: FlattenedPropEntry,
     pub value: PropertyValue,
@@ -55,6 +55,7 @@ impl Property {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Entity {
     pub server_class: ServerClassRef,
     pub id: i32,
@@ -95,5 +96,11 @@ impl Entity {
             .expect("property not found")
             .value
             .clone()
+    }
+
+    pub fn position(&self) -> Vector {
+        self.property_value("m_vecOrigin")
+            .map(|v| v.vector_val)
+            .unwrap_or_default()
     }
 }

--- a/demoinfocs-rs/src/sendtables/propdecoder.rs
+++ b/demoinfocs-rs/src/sendtables/propdecoder.rs
@@ -44,7 +44,7 @@ impl From<i32> for PropertyType {
 }
 
 bitflags! {
-    #[derive(Clone, Copy)]
+    #[derive(Debug, Clone, Copy, Default)]
     pub struct SendPropertyFlags: u32 {
         const UNSIGNED = 1 << 0;
         const COORD = 1 << 1;
@@ -69,7 +69,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SendTableProperty {
     pub flags: SendPropertyFlags,
     pub low_value: f32,

--- a/demoinfocs-rs/src/sendtables/serverclass.rs
+++ b/demoinfocs-rs/src/sendtables/serverclass.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use super::entity::FlattenedPropEntry;
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct ServerClass {
     pub id: i32,
     pub name: String,
@@ -82,12 +82,7 @@ impl fmt::Display for ServerClass {
         write!(
             f,
             "serverClass: id={} name={}\n\tdataTableId={}\n\tdataTableName={}\n\tbaseClasses:\n\t\t{}\n\tproperties:\n\t\t{}",
-            self.id,
-            self.name,
-            self.data_table_id,
-            self.data_table_name,
-            base,
-            props
+            self.id, self.name, self.data_table_id, self.data_table_name, base, props
         )
     }
 }


### PR DESCRIPTION
## Summary
- expose datatable module
- add user message handler registration
- avoid duplicate enum variants
- derive Debug/Clone for sendtables types
- add ingame_tick to game state
- adjust game event dispatch

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml -q`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: ping_score_alive, active_weapon_and_weapons)*

------
https://chatgpt.com/codex/tasks/task_e_68664ae4adc48326a3db2b4dd48299f7