### PR TITLE
Add extra tests for utilities and player gear

### DIFF
--- a/demoinfocs-rs/tests/player.rs
+++ b/demoinfocs-rs/tests/player.rs
@@ -63,3 +63,34 @@ fn active_weapon_and_weapons() {
     assert!(p.active_weapon().is_some());
     assert_eq!(1, p.weapons().len());
 }
+
+#[test]
+fn equipment_values_and_gear() {
+    let ent = make_entity(vec![
+        ("m_unCurrentEquipmentValue", 1600),
+        ("m_unRoundStartEquipmentValue", 1500),
+        ("m_unFreezetimeEndEquipmentValue", 1400),
+        ("m_pItemServices.m_bHasDefuser", 1),
+        ("m_pItemServices.m_bHasHelmet", 0),
+    ]);
+    let p = Player {
+        entity: Some(ent),
+        ..Default::default()
+    };
+    assert_eq!(1600, p.equipment_value_current());
+    assert_eq!(1500, p.equipment_value_round_start());
+    assert_eq!(1400, p.equipment_value_freezetime_end());
+    assert!(p.has_defuse_kit());
+    assert!(!p.has_helmet());
+}
+
+#[test]
+fn gear_alt_property_names() {
+    let ent = make_entity(vec![("m_bHasDefuser", 1), ("m_bHasHelmet", 1)]);
+    let p = Player {
+        entity: Some(ent),
+        ..Default::default()
+    };
+    assert!(p.has_defuse_kit());
+    assert!(p.has_helmet());
+}

--- a/demoinfocs-rs/tests/steamid.rs
+++ b/demoinfocs-rs/tests/steamid.rs
@@ -1,0 +1,28 @@
+use demoinfocs_rs::utils::{
+    convert_steam_id32_to_64, convert_steam_id64_to_32, convert_steam_id_txt_to_32,
+};
+
+#[test]
+fn convert_txt_to_32() {
+    let id = convert_steam_id_txt_to_32("STEAM_0:1:26343269").unwrap();
+    assert_eq!(52686539, id);
+}
+
+#[test]
+fn convert_txt_to_32_error() {
+    assert!(convert_steam_id_txt_to_32("STEAM_0:1:a").is_err());
+    assert!(convert_steam_id_txt_to_32("STEAM_0:b:21643603").is_err());
+    assert!(convert_steam_id_txt_to_32("STEAM_0:b").is_err());
+}
+
+#[test]
+fn convert_32_to_64() {
+    let id = convert_steam_id32_to_64(52686539);
+    assert_eq!(76561198012952267u64, id);
+}
+
+#[test]
+fn convert_64_to_32() {
+    let id = convert_steam_id64_to_32(76561198012952267u64);
+    assert_eq!(52686539u32, id);
+}


### PR DESCRIPTION
## Summary
- add SteamID conversion tests in the integration test directory
- extend player tests to cover equipment values and gear helpers

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check` *(fails: produced diffs)*
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml -q` *(fails to compile)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68664af1c0ec83269853fc3f0842e622