### PR TITLE
Fix property lookup without server class

### DIFF
--- a/demoinfocs-rs/src/sendtables/entity.rs
+++ b/demoinfocs-rs/src/sendtables/entity.rs
@@ -79,6 +79,13 @@ impl Entity {
         self.props.iter().collect()
     }
     fn property(&self, name: &str) -> Option<&Property> {
+        if self.server_class.flattened_props.is_empty() {
+            // Tests may construct `Entity` instances manually without a fully
+            // populated `ServerClass`. In that case fall back to a linear
+            // search through all properties by name.
+            return self.props.iter().find(|p| p.name() == name);
+        }
+
         self.server_class
             .flattened_props
             .iter()


### PR DESCRIPTION
## Summary
- handle Entities that do not have ServerClass data
- pass tests

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686650e860548326b116c439d19b30b6