### PR TITLE
Fix example README paths

### DIFF
--- a/examples/encrypted-net-messages/README.md
+++ b/examples/encrypted-net-messages/README.md
@@ -9,6 +9,6 @@ The key then needs to be passed to `ParserConfig.NetMessageDecryptionKey`.
 
 ## Run
 
-    go run enc_net_nsg.go -demo path/to/demo.dem -info path/to/demo.dem.info
+    cargo run --example encrypted_net_messages -- -demo path/to/demo.dem -info path/to/demo.dem.info
 
 This prints chat messages from the passed demo (assuming the `.dem.info` file contains the correct decryption key).

--- a/examples/entities/README.md
+++ b/examples/entities/README.md
@@ -6,9 +6,9 @@ This example shows how to use unhandled data of entities by registering entity-c
 
 You can use the build tag `debugdemoinfocs` and the set `debugServerClasses=YES` with ldflags to find interesting server-classes and their properties.
 
-Example: `go run myprogram.go -tags debugdemoinfocs -ldflags '-X github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs.debugServerClasses=YES' | grep ServerClass`
+Example: `cargo run --example myprogram -- -tags debugdemoinfocs -ldflags '-X github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs.debugServerClasses=YES' | grep ServerClass`
 
-This gives you a list of all server-classes from any demo that was parsed in `myprogram.go`.
+This gives you a list of all server-classes from any demo that was parsed in `myprogram.rs`.
 
 <details>
 <summary>Sample output</summary>
@@ -839,7 +839,7 @@ p.RegisterEventHandler(func(events.DataTablesParsed) {
 
 The Example prints the life-cycle of all AWPs during the game - i.e. who picked up whose AWP.
 
-`go run server_classes.go -demo /path/to/demo`
+`cargo run --example server_classes -- -demo /path/to/demo`
 
 Sample output:
 

--- a/examples/heatmap/README.md
+++ b/examples/heatmap/README.md
@@ -4,11 +4,11 @@ This example shows how to create a heatmap from positions where players fired th
 
 :information_source: Uses radar images from `../_assets/radar` directory.
 
-See `heatmap.go` for the source code.
+See [`demoinfocs-rs/examples/heatmap.rs`](../../demoinfocs-rs/examples/heatmap.rs) for the source code.
 
 ## Running the example
 
-`go run heatmap.go -demo /path/to/demo > out.jpg`
+`cargo run --example heatmap -- -demo /path/to/demo > out.jpg`
 
 This will create a JPEG of a radar overview with dots on all the locations where shots were fired from.
 

--- a/examples/nade-trajectories/README.md
+++ b/examples/nade-trajectories/README.md
@@ -6,7 +6,7 @@ This example shows how to create a overview of grenade trajectories of a match.
 
 ## Running the example
 
-`go run nade_trajectories.go -demo /path/to/demo > out.jpg`
+`cargo run --example nade_trajectories -- -demo /path/to/demo > out.jpg`
 
 This will create a JPEG with grenade trajectories of the first five rounds. The reason it doesn't do more trajectories is because the image would look quite cluttered otherwise.
 

--- a/examples/print-events/README.md
+++ b/examples/print-events/README.md
@@ -4,7 +4,7 @@ This example shows how to use the library to print out information of some key g
 
 ## Running the example
 
-`go run print_events.go -demo /path/to/demo`
+`cargo run --example print_events -- -demo /path/to/demo`
 
 ### Sample output
 


### PR DESCRIPTION
## Summary
- update example READMEs to reference Rust examples instead of Go

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml` *(fails: could not compile `demoinfocs-rs`)*
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: could not compile `demoinfocs-rs`)*

------
https://chatgpt.com/codex/tasks/task_e_686659a73f8c8326ad5a83f4caede5a6