### PR TITLE
Implement bomb game events

### DIFF
--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -355,6 +355,11 @@ pub struct BombPickup {
 }
 
 #[derive(Clone, Debug)]
+pub struct BombBeep {
+    pub inner: BombEvent,
+}
+
+#[derive(Clone, Debug)]
 pub struct HostageRescued {
     pub player: Option<Player>,
     pub hostage: Option<Hostage>,

--- a/demoinfocs-rs/src/game_events.rs
+++ b/demoinfocs-rs/src/game_events.rs
@@ -59,6 +59,45 @@ impl GameEventHandler {
                 winner_state: None,
                 loser_state: None,
             }),
+            | "bomb_beginplant" => parser.dispatch_event(events::BombPlantBegin {
+                inner: events::BombEvent {
+                    player: None,
+                    site: events::Bombsite::Unknown,
+                },
+            }),
+            | "bomb_begindefuse" => parser.dispatch_event(events::BombDefuseStart {
+                player: None,
+                has_kit: false,
+            }),
+            | "bomb_defused" => parser.dispatch_event(events::BombDefused {
+                inner: events::BombEvent {
+                    player: None,
+                    site: events::Bombsite::Unknown,
+                },
+            }),
+            | "bomb_exploded" => parser.dispatch_event(events::BombExplode {
+                inner: events::BombEvent {
+                    player: None,
+                    site: events::Bombsite::Unknown,
+                },
+            }),
+            | "bomb_dropped" => parser.dispatch_event(events::BombDropped {
+                player: None,
+                entity_id: 0,
+            }),
+            | "bomb_pickup" => parser.dispatch_event(events::BombPickup { player: None }),
+            | "bomb_planted" => parser.dispatch_event(events::BombPlanted {
+                inner: events::BombEvent {
+                    player: None,
+                    site: events::Bombsite::Unknown,
+                },
+            }),
+            | "bomb_beep" => parser.dispatch_event(events::BombBeep {
+                inner: events::BombEvent {
+                    player: None,
+                    site: events::Bombsite::Unknown,
+                },
+            }),
             | _ => {},
         }
     }

--- a/demoinfocs-rs/tests/game_events.rs
+++ b/demoinfocs-rs/tests/game_events.rs
@@ -73,3 +73,116 @@ fn dispatch_basic_game_events() {
     assert!(rs.load(Ordering::SeqCst) >= 1);
     assert!(re.load(Ordering::SeqCst) >= 1);
 }
+
+#[test]
+fn dispatch_bomb_game_events() {
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+
+    let beginplant = Arc::new(AtomicUsize::new(0));
+    let begindefuse = Arc::new(AtomicUsize::new(0));
+    let defused = Arc::new(AtomicUsize::new(0));
+    let exploded = Arc::new(AtomicUsize::new(0));
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let pickup = Arc::new(AtomicUsize::new(0));
+    let planted = Arc::new(AtomicUsize::new(0));
+    let beep = Arc::new(AtomicUsize::new(0));
+
+    let c = beginplant.clone();
+    parser.register_event_handler::<events::BombPlantBegin, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = begindefuse.clone();
+    parser.register_event_handler::<events::BombDefuseStart, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = defused.clone();
+    parser.register_event_handler::<events::BombDefused, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = exploded.clone();
+    parser.register_event_handler::<events::BombExplode, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = dropped.clone();
+    parser.register_event_handler::<events::BombDropped, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = pickup.clone();
+    parser.register_event_handler::<events::BombPickup, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = planted.clone();
+    parser.register_event_handler::<events::BombPlanted, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = beep.clone();
+    parser.register_event_handler::<events::BombBeep, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let list = msg::CsvcMsgGameEventList {
+        descriptors: vec![
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(1),
+                name: Some("bomb_beginplant".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(2),
+                name: Some("bomb_begindefuse".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(3),
+                name: Some("bomb_defused".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(4),
+                name: Some("bomb_exploded".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(5),
+                name: Some("bomb_dropped".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(6),
+                name: Some("bomb_pickup".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(7),
+                name: Some("bomb_planted".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(8),
+                name: Some("bomb_beep".into()),
+                keys: vec![],
+            },
+        ],
+    };
+    parser.on_game_event_list(&list);
+
+    for id in 1..=8 {
+        parser.on_game_event(&msg::CsvcMsgGameEvent {
+            event_name: None,
+            eventid: Some(id),
+            keys: vec![],
+            passthrough: None,
+        });
+    }
+
+    thread::sleep(std::time::Duration::from_millis(20));
+
+    assert!(beginplant.load(Ordering::SeqCst) >= 1);
+    assert!(begindefuse.load(Ordering::SeqCst) >= 1);
+    assert!(defused.load(Ordering::SeqCst) >= 1);
+    assert!(exploded.load(Ordering::SeqCst) >= 1);
+    assert!(dropped.load(Ordering::SeqCst) >= 1);
+    assert!(pickup.load(Ordering::SeqCst) >= 1);
+    assert!(planted.load(Ordering::SeqCst) >= 1);
+    assert!(beep.load(Ordering::SeqCst) >= 1);
+}


### PR DESCRIPTION
## Summary
- handle bomb-related game events
- define `BombBeep` event
- test dispatching of bomb events

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68672179ff488326a722688b4e381f4a