### PR TITLE
Implement grenade start events

### DIFF
--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -231,6 +231,18 @@ pub struct GrenadeEvent {
     pub grenade_entity_id: i32,
 }
 
+impl Default for GrenadeEvent {
+    fn default() -> Self {
+        Self {
+            grenade_type: 0,
+            grenade: None,
+            position: Vector::default(),
+            thrower: None,
+            grenade_entity_id: 0,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct HeExplode {
     pub inner: GrenadeEvent,

--- a/demoinfocs-rs/src/game_events.rs
+++ b/demoinfocs-rs/src/game_events.rs
@@ -59,6 +59,30 @@ impl GameEventHandler {
                 winner_state: None,
                 loser_state: None,
             }),
+            | "flashbang_detonate" => parser.dispatch_event(events::FlashExplode {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "hegrenade_detonate" => parser.dispatch_event(events::HeExplode {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "decoy_started" => parser.dispatch_event(events::DecoyStart {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "decoy_detonate" => parser.dispatch_event(events::DecoyExpired {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "smokegrenade_detonate" => parser.dispatch_event(events::SmokeStart {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "smokegrenade_expired" => parser.dispatch_event(events::SmokeExpired {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "inferno_startburn" => parser.dispatch_event(events::FireGrenadeStart {
+                inner: events::GrenadeEvent::default(),
+            }),
+            | "inferno_expire" => parser.dispatch_event(events::FireGrenadeExpired {
+                inner: events::GrenadeEvent::default(),
+            }),
             | _ => {},
         }
     }

--- a/demoinfocs-rs/tests/game_events.rs
+++ b/demoinfocs-rs/tests/game_events.rs
@@ -73,3 +73,116 @@ fn dispatch_basic_game_events() {
     assert!(rs.load(Ordering::SeqCst) >= 1);
     assert!(re.load(Ordering::SeqCst) >= 1);
 }
+
+#[test]
+fn dispatch_grenade_game_events() {
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+
+    let flash = Arc::new(AtomicUsize::new(0));
+    let he = Arc::new(AtomicUsize::new(0));
+    let decoy_start = Arc::new(AtomicUsize::new(0));
+    let decoy_end = Arc::new(AtomicUsize::new(0));
+    let smoke_start = Arc::new(AtomicUsize::new(0));
+    let smoke_end = Arc::new(AtomicUsize::new(0));
+    let fire_start = Arc::new(AtomicUsize::new(0));
+    let fire_end = Arc::new(AtomicUsize::new(0));
+
+    let flash_c = flash.clone();
+    parser.register_event_handler::<events::FlashExplode, _>(move |_| {
+        flash_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let he_c = he.clone();
+    parser.register_event_handler::<events::HeExplode, _>(move |_| {
+        he_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let decoy_start_c = decoy_start.clone();
+    parser.register_event_handler::<events::DecoyStart, _>(move |_| {
+        decoy_start_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let decoy_end_c = decoy_end.clone();
+    parser.register_event_handler::<events::DecoyExpired, _>(move |_| {
+        decoy_end_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let smoke_start_c = smoke_start.clone();
+    parser.register_event_handler::<events::SmokeStart, _>(move |_| {
+        smoke_start_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let smoke_end_c = smoke_end.clone();
+    parser.register_event_handler::<events::SmokeExpired, _>(move |_| {
+        smoke_end_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let fire_start_c = fire_start.clone();
+    parser.register_event_handler::<events::FireGrenadeStart, _>(move |_| {
+        fire_start_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let fire_end_c = fire_end.clone();
+    parser.register_event_handler::<events::FireGrenadeExpired, _>(move |_| {
+        fire_end_c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let list = msg::CsvcMsgGameEventList {
+        descriptors: vec![
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(1),
+                name: Some("flashbang_detonate".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(2),
+                name: Some("hegrenade_detonate".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(3),
+                name: Some("decoy_started".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(4),
+                name: Some("decoy_detonate".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(5),
+                name: Some("smokegrenade_detonate".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(6),
+                name: Some("smokegrenade_expired".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(7),
+                name: Some("inferno_startburn".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(8),
+                name: Some("inferno_expire".into()),
+                keys: vec![],
+            },
+        ],
+    };
+    parser.on_game_event_list(&list);
+
+    for id in 1..=8 {
+        parser.on_game_event(&msg::CsvcMsgGameEvent {
+            event_name: None,
+            eventid: Some(id),
+            keys: vec![],
+            passthrough: None,
+        });
+    }
+
+    thread::sleep(std::time::Duration::from_millis(20));
+
+    assert!(flash.load(Ordering::SeqCst) >= 1);
+    assert!(he.load(Ordering::SeqCst) >= 1);
+    assert!(decoy_start.load(Ordering::SeqCst) >= 1);
+    assert!(decoy_end.load(Ordering::SeqCst) >= 1);
+    assert!(smoke_start.load(Ordering::SeqCst) >= 1);
+    assert!(smoke_end.load(Ordering::SeqCst) >= 1);
+    assert!(fire_start.load(Ordering::SeqCst) >= 1);
+    assert!(fire_end.load(Ordering::SeqCst) >= 1);
+}


### PR DESCRIPTION
## Summary
- add a `Default` impl for `GrenadeEvent`
- dispatch grenade start/expire events in `GameEventHandler`
- test dispatching of grenade events

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686721830f50832692c4711369996f39