### PR TITLE
Add round-state notification events

### DIFF
--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -164,6 +164,24 @@ pub struct AnnouncementFinalRound;
 pub struct AnnouncementWinPanelMatch;
 
 #[derive(Clone, Debug)]
+pub struct RoundAnnounceFinal;
+
+#[derive(Clone, Debug)]
+pub struct RoundAnnounceLastRoundHalf;
+
+#[derive(Clone, Debug)]
+pub struct RoundAnnounceMatchPoint;
+
+#[derive(Clone, Debug)]
+pub struct RoundAnnounceMatchStart;
+
+#[derive(Clone, Debug)]
+pub struct RoundAnnounceWarmup;
+
+#[derive(Clone, Debug)]
+pub struct RoundEndUploadStats;
+
+#[derive(Clone, Debug)]
 pub struct Footstep {
     pub player: Option<Player>,
 }

--- a/demoinfocs-rs/src/game_events.rs
+++ b/demoinfocs-rs/src/game_events.rs
@@ -59,6 +59,24 @@ impl GameEventHandler {
                 winner_state: None,
                 loser_state: None,
             }),
+            | "round_announce_final" => parser.dispatch_event(events::RoundAnnounceFinal),
+            | "round_announce_last_round_half" => {
+                parser.dispatch_event(events::RoundAnnounceLastRoundHalf)
+            },
+            | "round_announce_match_point" => {
+                parser.dispatch_event(events::RoundAnnounceMatchPoint)
+            },
+            | "round_announce_match_start" => {
+                parser.dispatch_event(events::RoundAnnounceMatchStart)
+            },
+            | "round_announce_warmup" => parser.dispatch_event(events::RoundAnnounceWarmup),
+            | "round_end_upload_stats" => parser.dispatch_event(events::RoundEndUploadStats),
+            | "round_mvp" => parser.dispatch_event(events::RoundMVPAnnouncement {
+                player: None,
+                reason: events::RoundMVPReason::MostEliminations,
+            }),
+            | "round_freeze_end" => parser.dispatch_event(events::RoundFreezetimeEnd),
+            | "round_officially_ended" => parser.dispatch_event(events::RoundEndOfficial),
             | _ => {},
         }
     }

--- a/demoinfocs-rs/tests/game_events.rs
+++ b/demoinfocs-rs/tests/game_events.rs
@@ -73,3 +73,127 @@ fn dispatch_basic_game_events() {
     assert!(rs.load(Ordering::SeqCst) >= 1);
     assert!(re.load(Ordering::SeqCst) >= 1);
 }
+
+#[test]
+fn dispatch_round_state_events() {
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+
+    let final_c = Arc::new(AtomicUsize::new(0));
+    let last_half_c = Arc::new(AtomicUsize::new(0));
+    let match_point_c = Arc::new(AtomicUsize::new(0));
+    let match_start_c = Arc::new(AtomicUsize::new(0));
+    let warmup_c = Arc::new(AtomicUsize::new(0));
+    let upload_stats_c = Arc::new(AtomicUsize::new(0));
+    let mvp_c = Arc::new(AtomicUsize::new(0));
+    let freeze_end_c = Arc::new(AtomicUsize::new(0));
+    let official_c = Arc::new(AtomicUsize::new(0));
+
+    let c = final_c.clone();
+    parser.register_event_handler::<events::RoundAnnounceFinal, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = last_half_c.clone();
+    parser.register_event_handler::<events::RoundAnnounceLastRoundHalf, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = match_point_c.clone();
+    parser.register_event_handler::<events::RoundAnnounceMatchPoint, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = match_start_c.clone();
+    parser.register_event_handler::<events::RoundAnnounceMatchStart, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = warmup_c.clone();
+    parser.register_event_handler::<events::RoundAnnounceWarmup, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = upload_stats_c.clone();
+    parser.register_event_handler::<events::RoundEndUploadStats, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = mvp_c.clone();
+    parser.register_event_handler::<events::RoundMVPAnnouncement, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = freeze_end_c.clone();
+    parser.register_event_handler::<events::RoundFreezetimeEnd, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = official_c.clone();
+    parser.register_event_handler::<events::RoundEndOfficial, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let list = msg::CsvcMsgGameEventList {
+        descriptors: vec![
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(1),
+                name: Some("round_announce_final".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(2),
+                name: Some("round_announce_last_round_half".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(3),
+                name: Some("round_announce_match_point".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(4),
+                name: Some("round_announce_match_start".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(5),
+                name: Some("round_announce_warmup".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(6),
+                name: Some("round_end_upload_stats".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(7),
+                name: Some("round_mvp".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(8),
+                name: Some("round_freeze_end".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(9),
+                name: Some("round_officially_ended".into()),
+                keys: vec![],
+            },
+        ],
+    };
+    parser.on_game_event_list(&list);
+
+    for id in 1..=9 {
+        parser.on_game_event(&msg::CsvcMsgGameEvent {
+            event_name: None,
+            eventid: Some(id),
+            keys: vec![],
+            passthrough: None,
+        });
+    }
+
+    thread::sleep(std::time::Duration::from_millis(20));
+
+    assert!(final_c.load(Ordering::SeqCst) >= 1);
+    assert!(last_half_c.load(Ordering::SeqCst) >= 1);
+    assert!(match_point_c.load(Ordering::SeqCst) >= 1);
+    assert!(match_start_c.load(Ordering::SeqCst) >= 1);
+    assert!(warmup_c.load(Ordering::SeqCst) >= 1);
+    assert!(upload_stats_c.load(Ordering::SeqCst) >= 1);
+    assert!(mvp_c.load(Ordering::SeqCst) >= 1);
+    assert!(freeze_end_c.load(Ordering::SeqCst) >= 1);
+    assert!(official_c.load(Ordering::SeqCst) >= 1);
+}


### PR DESCRIPTION
## Summary
- define new round-state notification structs
- map round announcement events
- test round-state event dispatch

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6867218411588326943f3264814e7989