### PR TITLE
Add equipment and general server event structs

### DIFF
--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -554,3 +554,30 @@ pub struct TeamClanNameUpdated {
     pub new_name: String,
     pub team_state: Option<TeamState>,
 }
+
+#[derive(Clone, Debug)]
+pub struct AmmoPickup;
+
+#[derive(Clone, Debug)]
+pub struct ItemEquip;
+
+#[derive(Clone, Debug)]
+pub struct ItemPickup;
+
+#[derive(Clone, Debug)]
+pub struct ItemPickupSlerp;
+
+#[derive(Clone, Debug)]
+pub struct ItemRemove;
+
+#[derive(Clone, Debug)]
+pub struct InspectWeapon;
+
+#[derive(Clone, Debug)]
+pub struct ServerCvar;
+
+#[derive(Clone, Debug)]
+pub struct VoteCast;
+
+#[derive(Clone, Debug)]
+pub struct TournamentReward;

--- a/demoinfocs-rs/src/game_events.rs
+++ b/demoinfocs-rs/src/game_events.rs
@@ -59,6 +59,15 @@ impl GameEventHandler {
                 winner_state: None,
                 loser_state: None,
             }),
+            | "ammo_pickup" => parser.dispatch_event(events::AmmoPickup),
+            | "item_equip" => parser.dispatch_event(events::ItemEquip),
+            | "item_pickup" => parser.dispatch_event(events::ItemPickup),
+            | "item_pickup_slerp" => parser.dispatch_event(events::ItemPickupSlerp),
+            | "item_remove" => parser.dispatch_event(events::ItemRemove),
+            | "inspect_weapon" => parser.dispatch_event(events::InspectWeapon),
+            | "server_cvar" => parser.dispatch_event(events::ServerCvar),
+            | "vote_cast" => parser.dispatch_event(events::VoteCast),
+            | "tournament_reward" => parser.dispatch_event(events::TournamentReward),
             | _ => {},
         }
     }

--- a/demoinfocs-rs/tests/game_events.rs
+++ b/demoinfocs-rs/tests/game_events.rs
@@ -73,3 +73,91 @@ fn dispatch_basic_game_events() {
     assert!(rs.load(Ordering::SeqCst) >= 1);
     assert!(re.load(Ordering::SeqCst) >= 1);
 }
+
+#[test]
+fn dispatch_equipment_and_server_events() {
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+
+    let ammo = Arc::new(AtomicUsize::new(0));
+    let equip = Arc::new(AtomicUsize::new(0));
+    let pickup = Arc::new(AtomicUsize::new(0));
+    let slerp = Arc::new(AtomicUsize::new(0));
+    let remove = Arc::new(AtomicUsize::new(0));
+    let inspect = Arc::new(AtomicUsize::new(0));
+    let cvar = Arc::new(AtomicUsize::new(0));
+    let vote = Arc::new(AtomicUsize::new(0));
+    let reward = Arc::new(AtomicUsize::new(0));
+
+    let c = ammo.clone();
+    parser.register_event_handler::<events::AmmoPickup, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = equip.clone();
+    parser.register_event_handler::<events::ItemEquip, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = pickup.clone();
+    parser.register_event_handler::<events::ItemPickup, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = slerp.clone();
+    parser.register_event_handler::<events::ItemPickupSlerp, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = remove.clone();
+    parser.register_event_handler::<events::ItemRemove, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = inspect.clone();
+    parser.register_event_handler::<events::InspectWeapon, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = cvar.clone();
+    parser.register_event_handler::<events::ServerCvar, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = vote.clone();
+    parser.register_event_handler::<events::VoteCast, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    let c = reward.clone();
+    parser.register_event_handler::<events::TournamentReward, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let list = msg::CsvcMsgGameEventList {
+        descriptors: vec![
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(1), name: Some("ammo_pickup".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(2), name: Some("item_equip".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(3), name: Some("item_pickup".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(4), name: Some("item_pickup_slerp".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(5), name: Some("item_remove".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(6), name: Some("inspect_weapon".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(7), name: Some("server_cvar".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(8), name: Some("vote_cast".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(9), name: Some("tournament_reward".into()), keys: vec![] },
+        ],
+    };
+    parser.on_game_event_list(&list);
+
+    for id in 1..=9 {
+        parser.on_game_event(&msg::CsvcMsgGameEvent {
+            event_name: None,
+            eventid: Some(id),
+            keys: vec![],
+            passthrough: None,
+        });
+    }
+
+    thread::sleep(std::time::Duration::from_millis(20));
+
+    assert!(ammo.load(Ordering::SeqCst) >= 1);
+    assert!(equip.load(Ordering::SeqCst) >= 1);
+    assert!(pickup.load(Ordering::SeqCst) >= 1);
+    assert!(slerp.load(Ordering::SeqCst) >= 1);
+    assert!(remove.load(Ordering::SeqCst) >= 1);
+    assert!(inspect.load(Ordering::SeqCst) >= 1);
+    assert!(cvar.load(Ordering::SeqCst) >= 1);
+    assert!(vote.load(Ordering::SeqCst) >= 1);
+    assert!(reward.load(Ordering::SeqCst) >= 1);
+}


### PR DESCRIPTION
## Summary
- add various equipment and server events
- map additional event names in `GameEventHandler`
- test dispatching of new events

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6867218680e0832691582ae292c3a875