### PR TITLE
Improve protobuf include handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ sudo apt-get install protobuf-compiler libprotobuf-dev
 If `PROTOC_INCLUDE` is set, the build script will use it to locate
 `google/protobuf/descriptor.proto`. When `prost-build` is built with its
 bundled `protoc`, this variable is provided automatically.
+Otherwise the build script falls back to common system locations such as
+`/usr/include` or `/usr/local/include`. Installing `libprotobuf-dev` on
+Debian/Ubuntu provides the descriptor in `/usr/include`.
 
 ### Demo files
 

--- a/demoinfocs-rs/README.md
+++ b/demoinfocs-rs/README.md
@@ -19,6 +19,11 @@ buffer definitions. Install it via your package manager, e.g. on Debian/Ubuntu:
 sudo apt-get install protobuf-compiler
 ```
 
+If the build script cannot locate `google/protobuf/descriptor.proto`, install
+`libprotobuf-dev` and set the `PROTOC_INCLUDE` environment variable to the
+directory containing that file. When using the system packages on
+Debian/Ubuntu, this is `/usr/include` and no environment variable is needed.
+
 ## Examples
 
 Several small examples are available under `examples/`. To run one of them, supply the demo path via the `-demo` flag. For example:

--- a/demoinfocs-rs/build.rs
+++ b/demoinfocs-rs/build.rs
@@ -69,6 +69,14 @@ fn compile(input: &str, output: &str) -> Result<(), Box<dyn std::error::Error>> 
     let mut includes: Vec<PathBuf> = vec![in_dir.clone()];
     if let Ok(protoc_include) = std::env::var("PROTOC_INCLUDE") {
         includes.push(PathBuf::from(protoc_include));
+    } else {
+        for fallback in ["/usr/include", "/usr/local/include"] {
+            let candidate = Path::new(fallback).join("google/protobuf/descriptor.proto");
+            if candidate.exists() {
+                includes.push(PathBuf::from(fallback));
+                break;
+            }
+        }
     }
     config.compile_protos(&protos, &includes)?;
     Ok(())

--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -716,7 +716,6 @@ pub struct WeaponZoom;
 
 #[derive(Clone, Debug)]
 pub struct WeaponZoomRifle;
-=======
 pub struct AmmoPickup;
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary
- default `build.rs` to common system protobuf includes
- document installing `libprotobuf-dev` and include fallback paths
- fix stray line in `events.rs`

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml --no-run --lib`

------
https://chatgpt.com/codex/tasks/task_e_68674b52052883268b0f6c47d04e826a