### PR TITLE
Add entity event support

### DIFF
--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -716,7 +716,8 @@ pub struct WeaponZoom;
 
 #[derive(Clone, Debug)]
 pub struct WeaponZoomRifle;
-=======
+
+#[derive(Clone, Debug)]
 pub struct AmmoPickup;
 
 #[derive(Clone, Debug)]

--- a/demoinfocs-rs/src/sendtables/entity_op.rs
+++ b/demoinfocs-rs/src/sendtables/entity_op.rs
@@ -1,0 +1,13 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct EntityOp: u8 {
+        const NONE = 0x00;
+        const CREATED = 0x01;
+        const UPDATED = 0x02;
+        const DELETED = 0x04;
+        const ENTERED = 0x08;
+        const LEFT = 0x10;
+    }
+}

--- a/demoinfocs-rs/src/sendtables/mod.rs
+++ b/demoinfocs-rs/src/sendtables/mod.rs
@@ -1,9 +1,11 @@
 pub mod entity;
+pub mod entity_op;
 pub mod parser;
 pub mod propdecoder;
 pub mod serverclass;
 
 pub use entity::{Entity, Property, PropertyValue};
+pub use entity_op::EntityOp;
 pub use parser::Parser as TablesParser;
 pub use parser::Parser as SendTableParser;
 pub use serverclass::{PropertyEntry, ServerClass};

--- a/demoinfocs-rs/tests/entity_callbacks.rs
+++ b/demoinfocs-rs/tests/entity_callbacks.rs
@@ -1,0 +1,49 @@
+use demoinfocs_rs::parser::{EntityEvent, Parser};
+use demoinfocs_rs::sendtables::EntityOp;
+use demoinfocs_rs::sendtables2::{Class, Entity};
+use std::io::Cursor;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+
+#[test]
+fn test_entity_handlers() {
+    let mut p = Parser::new(Cursor::new(Vec::<u8>::new()));
+
+    let on_entity = Arc::new(AtomicUsize::new(0));
+    let on_created = Arc::new(AtomicUsize::new(0));
+
+    let oe_c = on_entity.clone();
+    p.register_on_entity(move |_| {
+        oe_c.fetch_add(1, Ordering::SeqCst);
+    });
+    let oc_c = on_created.clone();
+    p.register_on_entity_created(move |_| {
+        oc_c.fetch_add(1, Ordering::SeqCst);
+    });
+
+    let ent = Entity {
+        index: 1,
+        serial: 1,
+        class: Class {
+            class_id: 0,
+            name: "Test".into(),
+            serializer: None,
+        },
+    };
+
+    p.dispatch_event(EntityEvent {
+        entity: ent.clone(),
+        op: EntityOp::CREATED,
+    });
+    p.dispatch_event(EntityEvent {
+        entity: ent.clone(),
+        op: EntityOp::UPDATED,
+    });
+
+    thread::sleep(std::time::Duration::from_millis(10));
+
+    assert_eq!(2, on_entity.load(Ordering::SeqCst));
+    assert_eq!(1, on_created.load(Ordering::SeqCst));
+    assert!(p.game_state().entities().get(&1).is_some());
+}

--- a/demoinfocs-rs/tests/game_events.rs
+++ b/demoinfocs-rs/tests/game_events.rs
@@ -88,45 +88,90 @@ fn dispatch_equipment_and_server_events() {
     let vote = Arc::new(AtomicUsize::new(0));
     let reward = Arc::new(AtomicUsize::new(0));
 
+    let ammo_c = ammo.clone();
     parser.register_event_handler::<events::AmmoPickup, _>(move |_| {
-        ammo.fetch_add(1, Ordering::SeqCst);
+        ammo_c.fetch_add(1, Ordering::SeqCst);
     });
+    let equip_c = equip.clone();
     parser.register_event_handler::<events::ItemEquip, _>(move |_| {
-        equip.fetch_add(1, Ordering::SeqCst);
+        equip_c.fetch_add(1, Ordering::SeqCst);
     });
+    let pickup_c = pickup.clone();
     parser.register_event_handler::<events::ItemPickup, _>(move |_| {
-        pickup.fetch_add(1, Ordering::SeqCst);
+        pickup_c.fetch_add(1, Ordering::SeqCst);
     });
+    let slerp_c = slerp.clone();
     parser.register_event_handler::<events::ItemPickupSlerp, _>(move |_| {
-        slerp.fetch_add(1, Ordering::SeqCst);
+        slerp_c.fetch_add(1, Ordering::SeqCst);
     });
+    let remove_c = remove.clone();
     parser.register_event_handler::<events::ItemRemove, _>(move |_| {
-        remove.fetch_add(1, Ordering::SeqCst);
+        remove_c.fetch_add(1, Ordering::SeqCst);
     });
+    let inspect_c = inspect.clone();
     parser.register_event_handler::<events::InspectWeapon, _>(move |_| {
-        inspect.fetch_add(1, Ordering::SeqCst);
+        inspect_c.fetch_add(1, Ordering::SeqCst);
     });
+    let cvar_c = cvar.clone();
     parser.register_event_handler::<events::ServerCvar, _>(move |_| {
-        cvar.fetch_add(1, Ordering::SeqCst);
+        cvar_c.fetch_add(1, Ordering::SeqCst);
     });
+    let vote_c = vote.clone();
     parser.register_event_handler::<events::VoteCast, _>(move |_| {
-        vote.fetch_add(1, Ordering::SeqCst);
+        vote_c.fetch_add(1, Ordering::SeqCst);
     });
+    let reward_c = reward.clone();
     parser.register_event_handler::<events::TournamentReward, _>(move |_| {
-        reward.fetch_add(1, Ordering::SeqCst);
+        reward_c.fetch_add(1, Ordering::SeqCst);
     });
 
     let list = msg::CsvcMsgGameEventList {
         descriptors: vec![
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(1), name: Some("ammo_pickup".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(2), name: Some("item_equip".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(3), name: Some("item_pickup".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(4), name: Some("item_pickup_slerp".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(5), name: Some("item_remove".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(6), name: Some("inspect_weapon".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(7), name: Some("server_cvar".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(8), name: Some("vote_cast".into()), keys: vec![] },
-            msg::csvc_msg_game_event_list::DescriptorT { eventid: Some(9), name: Some("tournament_reward".into()), keys: vec![] },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(1),
+                name: Some("ammo_pickup".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(2),
+                name: Some("item_equip".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(3),
+                name: Some("item_pickup".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(4),
+                name: Some("item_pickup_slerp".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(5),
+                name: Some("item_remove".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(6),
+                name: Some("inspect_weapon".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(7),
+                name: Some("server_cvar".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(8),
+                name: Some("vote_cast".into()),
+                keys: vec![],
+            },
+            msg::csvc_msg_game_event_list::DescriptorT {
+                eventid: Some(9),
+                name: Some("tournament_reward".into()),
+                keys: vec![],
+            },
         ],
     };
     parser.on_game_event_list(&list);
@@ -167,32 +212,41 @@ fn dispatch_round_state_events() {
     let freeze_end_c = Arc::new(AtomicUsize::new(0));
     let official_c = Arc::new(AtomicUsize::new(0));
 
+    let final_c_c = final_c.clone();
     parser.register_event_handler::<events::RoundAnnounceFinal, _>(move |_| {
-        final_c.fetch_add(1, Ordering::SeqCst);
+        final_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let last_half_c_c = last_half_c.clone();
     parser.register_event_handler::<events::RoundAnnounceLastRoundHalf, _>(move |_| {
-        last_half_c.fetch_add(1, Ordering::SeqCst);
+        last_half_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let match_point_c_c = match_point_c.clone();
     parser.register_event_handler::<events::RoundAnnounceMatchPoint, _>(move |_| {
-        match_point_c.fetch_add(1, Ordering::SeqCst);
+        match_point_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let match_start_c_c = match_start_c.clone();
     parser.register_event_handler::<events::RoundAnnounceMatchStart, _>(move |_| {
-        match_start_c.fetch_add(1, Ordering::SeqCst);
+        match_start_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let warmup_c_c = warmup_c.clone();
     parser.register_event_handler::<events::RoundAnnounceWarmup, _>(move |_| {
-        warmup_c.fetch_add(1, Ordering::SeqCst);
+        warmup_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let upload_stats_c_c = upload_stats_c.clone();
     parser.register_event_handler::<events::RoundEndUploadStats, _>(move |_| {
-        upload_stats_c.fetch_add(1, Ordering::SeqCst);
+        upload_stats_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let mvp_c_c = mvp_c.clone();
     parser.register_event_handler::<events::RoundMVPAnnouncement, _>(move |_| {
-        mvp_c.fetch_add(1, Ordering::SeqCst);
+        mvp_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let freeze_end_c_c = freeze_end_c.clone();
     parser.register_event_handler::<events::RoundFreezetimeEnd, _>(move |_| {
-        freeze_end_c.fetch_add(1, Ordering::SeqCst);
+        freeze_end_c_c.fetch_add(1, Ordering::SeqCst);
     });
+    let official_c_c = official_c.clone();
     parser.register_event_handler::<events::RoundEndOfficial, _>(move |_| {
-        official_c.fetch_add(1, Ordering::SeqCst);
+        official_c_c.fetch_add(1, Ordering::SeqCst);
     });
 
     let list = msg::CsvcMsgGameEventList {

--- a/demoinfocs-rs/tests/sendtables2.rs
+++ b/demoinfocs-rs/tests/sendtables2.rs
@@ -176,7 +176,12 @@ fn test_class_info_and_entities() {
         delta_from: Some(0),
         entity_data: Some(data),
     };
-    let created = p.parse_packet_entities(&pe_msg);
-    assert_eq!(created.len(), 1);
+    let events = p.parse_packet_entities(&pe_msg);
+    assert_eq!(events.len(), 1);
+    assert!(
+        events[0]
+            .1
+            .contains(demoinfocs_rs::sendtables::EntityOp::CREATED)
+    );
     assert!(p.entity(0).is_some());
 }


### PR DESCRIPTION
## Summary
- implement bitflag `EntityOp` for entity callbacks
- emit `EntityEvent` and `EntityCreated` from parser when parsing PacketEntities
- allow registration with `register_on_entity` and `register_on_entity_created`
- track entity events in `GameState`
- test entity callbacks and adjust existing tests

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68674b73e0bc832685ca514e8c8ee35b