### PR TITLE
Update README to clarify Go code status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cs-demo-parser
 
-This repository contains a Counter‑Strike demo parser that is now **entirely
-implemented in Rust**. The previous Go implementation has been removed.
+This repository contains a Counter‑Strike demo parser written in Rust.
+Old Go sources remain under `pkg/` and example directories but are no longer maintained; only the `demoinfocs-rs` crate is actively developed.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- mention old Go sources remain in `pkg/` and examples but are unmaintained
- note that only the `demoinfocs-rs` crate is actively developed

## Testing
- `cargo fmt -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml` *(fails: no `all` in `proto::msg`)*

------
https://chatgpt.com/codex/tasks/task_e_686857782d9883269dd9ee969d138de0