### PR TITLE
Handle more user messages

### DIFF
--- a/demoinfocs-rs/src/parser/mod.rs
+++ b/demoinfocs-rs/src/parser/mod.rs
@@ -497,6 +497,16 @@ impl<R: Read> Parser<R> {
                             self.dispatch_user_message(msg);
                         }
                     },
+                    | proto_msg::ECstrike15UserMessages::CsUmTextMsg => {
+                        if let Ok(msg) = proto_msg::CcsUsrMsgTextMsg::decode(&data[..]) {
+                            self.dispatch_user_message(msg);
+                        }
+                    },
+                    | proto_msg::ECstrike15UserMessages::CsUmHintText => {
+                        if let Ok(msg) = proto_msg::CcsUsrMsgHintText::decode(&data[..]) {
+                            self.dispatch_user_message(msg);
+                        }
+                    },
                     | _ => {},
                 }
             }


### PR DESCRIPTION
## Summary
- decode additional user message types in parser
- test hint, text, and round impact score user messages

## Testing
- `cargo fmt -- --check` *(fails: produced diffs)*
- `cargo clippy`
- `cargo test --manifest-path Cargo.toml` *(failed: test_server_class_string; unknown prop type)*

------
https://chatgpt.com/codex/tasks/task_e_68685bb340d88326845de9a7d4e957ff