### PR TITLE
Add string table parsing support

### DIFF
--- a/demoinfocs-rs/src/stringtables.rs
+++ b/demoinfocs-rs/src/stringtables.rs
@@ -18,6 +18,7 @@ pub struct StringTable {
 #[derive(Default)]
 pub struct StringTables {
     tables: HashMap<i32, StringTable>,
+    name_to_id: HashMap<String, i32>,
 }
 
 impl StringTables {
@@ -25,16 +26,28 @@ impl StringTables {
         Self::default()
     }
 
-    pub fn on_create_string_table(&mut self, msg: &msg::CsvcMsgCreateStringTable) {
+    pub fn get(&self, name: &str) -> Option<&StringTable> {
+        self.name_to_id.get(name).and_then(|id| self.tables.get(id))
+    }
+
+    pub fn on_create_string_table(
+        &mut self,
+        msg: &msg::CsvcMsgCreateStringTable,
+    ) -> Option<StringTable> {
         let id = self.tables.len() as i32;
         let table = StringTable {
             name: msg.name.clone().unwrap_or_default(),
             ..Default::default()
         };
-        self.tables.insert(id, table);
+        self.name_to_id.insert(table.name.clone(), id);
+        self.tables.insert(id, table.clone());
+        Some(table)
     }
 
-    pub fn on_update_string_table(&mut self, msg: &msg::CsvcMsgUpdateStringTable) {
+    pub fn on_update_string_table(
+        &mut self,
+        msg: &msg::CsvcMsgUpdateStringTable,
+    ) -> Option<StringTable> {
         if let Some(id) = msg.table_id {
             if let Some(table) = self.tables.get_mut(&id) {
                 if let Some(data) = &msg.string_data {
@@ -45,23 +58,21 @@ impl StringTables {
                     let idx = table.entries.len() as i32;
                     table.entries.insert(idx, entry);
                 }
+                return Some(table.clone());
             }
         }
+        None
     }
 
-    pub fn parse_svc_message(&mut self, typ: msg::SvcMessages, data: &[u8]) {
+    pub fn parse_svc_message(&mut self, typ: msg::SvcMessages, data: &[u8]) -> Option<StringTable> {
         match typ {
-            | msg::SvcMessages::SvcCreateStringTable => {
-                if let Ok(m) = msg::CsvcMsgCreateStringTable::decode(data) {
-                    self.on_create_string_table(&m);
-                }
-            },
-            | msg::SvcMessages::SvcUpdateStringTable => {
-                if let Ok(m) = msg::CsvcMsgUpdateStringTable::decode(data) {
-                    self.on_update_string_table(&m);
-                }
-            },
-            | _ => {},
+            | msg::SvcMessages::SvcCreateStringTable => msg::CsvcMsgCreateStringTable::decode(data)
+                .ok()
+                .and_then(|m| self.on_create_string_table(&m)),
+            | msg::SvcMessages::SvcUpdateStringTable => msg::CsvcMsgUpdateStringTable::decode(data)
+                .ok()
+                .and_then(|m| self.on_update_string_table(&m)),
+            | _ => None,
         }
     }
 }
@@ -85,7 +96,8 @@ fn read_var_uint32(slice: &mut &[u8]) -> u32 {
 }
 
 impl StringTables {
-    pub fn parse_packet(&mut self, data: &[u8]) {
+    pub fn parse_packet(&mut self, data: &[u8]) -> Vec<StringTable> {
+        let mut updates = Vec::new();
         let mut slice = data;
         while !slice.is_empty() {
             let msg_id = read_var_uint32(&mut slice);
@@ -96,8 +108,58 @@ impl StringTables {
             let (msg_buf, rest) = slice.split_at(size);
             slice = rest;
             if let Ok(t) = msg::SvcMessages::try_from(msg_id as i32) {
-                self.parse_svc_message(t, msg_buf);
+                if let Some(tbl) = self.parse_svc_message(t, msg_buf) {
+                    updates.push(tbl);
+                }
             }
         }
+        updates
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_var(buf: &mut Vec<u8>, mut value: u32) {
+        while value >= 0x80 {
+            buf.push(((value & 0x7f) as u8) | 0x80);
+            value >>= 7;
+        }
+        buf.push(value as u8);
+    }
+
+    #[test]
+    fn test_parse_and_lookup() {
+        let mut tables = StringTables::new();
+
+        let mut create = msg::CsvcMsgCreateStringTable::default();
+        create.name = Some("test".into());
+        let mut payload = Vec::new();
+        create.encode(&mut payload).unwrap();
+        let mut packet = Vec::new();
+        write_var(&mut packet, msg::SvcMessages::SvcCreateStringTable as u32);
+        write_var(&mut packet, payload.len() as u32);
+        packet.extend_from_slice(&payload);
+
+        let updates = tables.parse_packet(&packet);
+        assert_eq!(1, updates.len());
+        assert!(tables.get("test").is_some());
+
+        let mut update = msg::CsvcMsgUpdateStringTable::default();
+        update.table_id = Some(0);
+        update.num_changed_entries = Some(1);
+        update.string_data = Some(b"foo".to_vec());
+        let mut up_payload = Vec::new();
+        update.encode(&mut up_payload).unwrap();
+        let mut packet2 = Vec::new();
+        write_var(&mut packet2, msg::SvcMessages::SvcUpdateStringTable as u32);
+        write_var(&mut packet2, up_payload.len() as u32);
+        packet2.extend_from_slice(&up_payload);
+
+        let updates2 = tables.parse_packet(&packet2);
+        assert_eq!(1, updates2.len());
+        let tbl = tables.get("test").unwrap();
+        assert_eq!(tbl.entries.get(&0).unwrap().value, "foo");
     }
 }

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -4,7 +4,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 
 ## Core Parser
 - [x] **Source 1 demo support** – implement datatable and string table parsing similar to `pkg/demoinfocs/datatables.go` and `stringtables.go`.
-- [x] **String tables** – decode `svc_CreateStringTable` and `svc_UpdateStringTable` messages and expose APIs for consumers.
+- [x] **String tables** – decode `svc_CreateStringTable` and `svc_UpdateStringTable` messages and expose APIs for consumers. Use `parser.string_table(name)` to access tables and `parser.register_on_string_table` for update callbacks.
 - [ ] **Net message handling** – map all message types from `net_messages.go` and expose registration callbacks.
 - [ ] **Encrypted net messages** – port decryption helpers and error handling for encrypted messages.
 - [ ] **Parser configuration** – complete all options found in the Go `ParserConfig`.


### PR DESCRIPTION
## Summary
- implement StringTables parser with name lookup
- dispatch `StringTableUpdated` events from Parser
- expose `Parser::string_table` and registration helper
- document new API in PORTING_STATUS
- add unit tests for string table parsing

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68686c2beeb88326ab5ecfbd9c848ca7