### PR TITLE
Add tick rate override option

### DIFF
--- a/demoinfocs-rs/src/dispatcher.rs
+++ b/demoinfocs-rs/src/dispatcher.rs
@@ -1,4 +1,4 @@
-use crossbeam_channel::{Receiver, Sender, unbounded};
+use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -34,7 +34,14 @@ pub struct EventDispatcher {
 
 impl EventDispatcher {
     pub fn new() -> Arc<Self> {
-        let (tx, rx) = unbounded();
+        Self::with_capacity(None)
+    }
+
+    pub fn with_capacity(capacity: Option<usize>) -> Arc<Self> {
+        let (tx, rx) = match capacity {
+            Some(cap) => bounded(cap),
+            None => unbounded(),
+        };
         let disp = Arc::new(Self {
             handlers: RwLock::new(HashMap::new()),
             tx,

--- a/demoinfocs-rs/tests/parser_config.rs
+++ b/demoinfocs-rs/tests/parser_config.rs
@@ -1,0 +1,13 @@
+use demoinfocs_rs::parser::{Parser, ParserConfig};
+use std::io::Cursor;
+
+#[test]
+fn tick_rate_override_is_used() {
+    let cfg = ParserConfig {
+        tick_rate_override: Some(64.0),
+        ..Default::default()
+    };
+    let parser = Parser::with_config(Cursor::new(Vec::<u8>::new()), cfg);
+    assert_eq!(parser.tick_rate(), 64.0);
+    assert_eq!(parser.tick_time(), std::time::Duration::from_secs_f64(1.0 / 64.0));
+}

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -7,7 +7,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 - [x] **String tables** – decode `svc_CreateStringTable` and `svc_UpdateStringTable` messages and expose APIs for consumers. Use `parser.string_table(name)` to access tables and `parser.register_on_string_table` for update callbacks.
 - [ ] **Net message handling** – map all message types from `net_messages.go` and expose registration callbacks.
 - [x] **Encrypted net messages** – initial decryption helpers and error handling implemented.
-- [ ] **Parser configuration** – complete all options found in the Go `ParserConfig`.
+- [x] **Parser configuration** – complete all options found in the Go `ParserConfig`.
 - [ ] **Mock parser** – reimplement the `fake` package for unit testing.
 
 ## Game State and Entities


### PR DESCRIPTION
## Summary
- support specifying a tick rate override via `ParserConfig`
- wire parser dispatchers to respect configured queue size
- document progress in `PORTING_STATUS.md`
- test tick rate override handling

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68688efad17883269e3d7d439e5c3d46