### PR TITLE
Add missing ParserConfig option

### DIFF
--- a/demoinfocs-rs/src/parser/mod.rs
+++ b/demoinfocs-rs/src/parser/mod.rs
@@ -66,6 +66,9 @@ pub struct ParserConfig {
     /// Ignore malformed encrypted net-messages.
     pub ignore_bad_encrypted_data: bool,
 
+    /// Ignore encrypted net-message warnings when no decryption key is set.
+    pub ignore_missing_decryption_key: bool,
+
     /// Ignore errors about missing bombsite indices in game events.
     pub ignore_bombsite_index_not_found: bool,
 
@@ -92,6 +95,7 @@ impl Default for ParserConfig {
             source2_fallback_game_event_list_bin: None,
             ignore_packet_entities_panic: false,
             ignore_bad_encrypted_data: false,
+            ignore_missing_decryption_key: false,
             tick_rate_override: None,
         }
     }
@@ -555,8 +559,8 @@ impl<R: Read> Parser<R> {
                     });
                 }
             },
-            | _ => {
-                if !self.config.ignore_bad_encrypted_data {
+            | (None, Some(_)) => {
+                if !self.config.ignore_missing_decryption_key {
                     self.dispatch_event(crate::events::ParserWarn {
                         message: "received encrypted net-message but no decryption key is set"
                             .into(),
@@ -564,6 +568,7 @@ impl<R: Read> Parser<R> {
                     });
                 }
             },
+            | _ => {},
         }
     }
 

--- a/demoinfocs-rs/tests/parser_config.rs
+++ b/demoinfocs-rs/tests/parser_config.rs
@@ -11,3 +11,12 @@ fn tick_rate_override_is_used() {
     assert_eq!(parser.tick_rate(), 64.0);
     assert_eq!(parser.tick_time(), std::time::Duration::from_secs_f64(1.0 / 64.0));
 }
+
+#[test]
+fn ignore_missing_decryption_key_flag() {
+    let cfg = ParserConfig {
+        ignore_missing_decryption_key: true,
+        ..Default::default()
+    };
+    assert!(cfg.ignore_missing_decryption_key);
+}

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -8,6 +8,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 - [ ] **Net message handling** – map all message types from `net_messages.go` and expose registration callbacks.
 - [x] **Encrypted net messages** – initial decryption helpers and error handling implemented.
 - [x] **Parser configuration** – complete all options found in the Go `ParserConfig`.
+  New options include skipping warnings for missing decryption keys and overriding the tick rate.
 - [ ] **Mock parser** – reimplement the `fake` package for unit testing.
 
 ## Game State and Entities


### PR DESCRIPTION
## Summary
- add `ignore_missing_decryption_key` to `ParserConfig`
- apply new option when handling encrypted messages
- test the new config field
- document updated parser configuration status

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml -q`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6868aa4d574883269857415e7697105a