### PR TITLE
Add test mock parser

### DIFF
--- a/demoinfocs-rs/tests/demo_parsing.rs
+++ b/demoinfocs-rs/tests/demo_parsing.rs
@@ -1,25 +1,33 @@
-use demoinfocs_rs::parser::{Parser, ParserError};
-use std::fs::File;
-use std::io::Cursor;
-use std::path::PathBuf;
+#[path = "mock_parser.rs"]
+mod mock_parser;
 
-fn fixture_path(name: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("demos") // changed from demos-external to demos
-        .join(name)
-}
+use demoinfocs_rs::parser::{Parser, ParserError};
+use mock_parser::MockParser;
+use std::io::Cursor;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 
 #[test]
-#[ignore]
-fn parse_default_demo() {
-    let path = fixture_path("default.dem");
-    let file = File::open(&path).expect("failed to open demo");
-    let mut parser = Parser::new(file);
-    let err = parser.parse_to_end().unwrap_err();
-    assert!(matches!(
-        err,
-        ParserError::UnexpectedEndOfDemo | ParserError::InvalidFileType
-    ));
+fn parse_mock_demo() {
+    let mut parser = MockParser::new();
+    let ev_cnt = Arc::new(AtomicUsize::new(0));
+    let ev_c = ev_cnt.clone();
+    parser.register_event_handler::<u8, _>(move |v| {
+        ev_c.fetch_add(*v as usize, Ordering::SeqCst);
+    });
+    let msg_cnt = Arc::new(AtomicUsize::new(0));
+    let msg_c = msg_cnt.clone();
+    parser.register_net_message_handler::<u16, _>(move |m| {
+        msg_c.fetch_add(*m as usize, Ordering::SeqCst);
+    });
+    parser.feed_event(1u8);
+    parser.feed_net_message(2u16);
+    parser.parse_to_end();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    assert_eq!(1, ev_cnt.load(Ordering::SeqCst));
+    assert_eq!(2, msg_cnt.load(Ordering::SeqCst));
 }
 
 #[test]
@@ -32,13 +40,14 @@ fn invalid_file_type() {
 
 #[test]
 fn example_print_events_runs() {
-    let path = fixture_path("s2/s2.dem");
-    if let Ok(file) = File::open(&path) {
-        let mut parser = Parser::new(file);
-        parser.register_event_handler::<u8, _>(|_| {});
-        let err = parser.parse_to_end().unwrap_err();
-        if !matches!(err, ParserError::InvalidFileType) {
-            assert!(matches!(err, ParserError::UnexpectedEndOfDemo));
-        }
-    }
+    let mut parser = MockParser::new();
+    let called = Arc::new(AtomicUsize::new(0));
+    let c = called.clone();
+    parser.register_event_handler::<u8, _>(move |_| {
+        c.fetch_add(1, Ordering::SeqCst);
+    });
+    parser.feed_event(42u8);
+    parser.parse_to_end();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    assert_eq!(1, called.load(Ordering::SeqCst));
 }

--- a/demoinfocs-rs/tests/mock_parser.rs
+++ b/demoinfocs-rs/tests/mock_parser.rs
@@ -1,0 +1,83 @@
+use demoinfocs_rs::dispatcher::HandlerIdentifier;
+use demoinfocs_rs::events::FrameDone;
+use demoinfocs_rs::parser::Parser;
+use std::collections::VecDeque;
+use std::io::Cursor;
+
+pub struct MockParser {
+    parser: Parser<Cursor<Vec<u8>>>,
+    queue: VecDeque<Box<dyn FnOnce(&mut Parser<Cursor<Vec<u8>>>) + Send>>,
+}
+
+impl MockParser {
+    pub fn new() -> Self {
+        Self {
+            parser: Parser::new(Cursor::new(Vec::new())),
+            queue: VecDeque::new(),
+        }
+    }
+
+    pub fn feed_event<E>(&mut self, event: E)
+    where
+        E: Send + Sync + 'static,
+    {
+        self.queue
+            .push_back(Box::new(move |p| p.dispatch_event(event)));
+    }
+
+    pub fn feed_net_message<M>(&mut self, msg: M)
+    where
+        M: Send + Sync + 'static,
+    {
+        self.queue
+            .push_back(Box::new(move |p| p.dispatch_net_message(msg)));
+    }
+
+    pub fn parse_next_frame(&mut self) -> bool {
+        if let Some(cb) = self.queue.pop_front() {
+            cb(&mut self.parser);
+            self.parser.dispatch_event(FrameDone);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn parse_to_end(&mut self) {
+        while self.parse_next_frame() {}
+    }
+
+    pub fn register_event_handler<E, F>(&self, handler: F) -> HandlerIdentifier
+    where
+        E: Send + Sync + 'static,
+        F: Fn(&E) + Send + Sync + 'static,
+    {
+        self.parser.register_event_handler::<E, F>(handler)
+    }
+
+    pub fn register_net_message_handler<M, F>(&self, handler: F) -> HandlerIdentifier
+    where
+        M: Send + Sync + 'static,
+        F: Fn(&M) + Send + Sync + 'static,
+    {
+        self.parser.register_net_message_handler::<M, F>(handler)
+    }
+
+    pub fn unregister_event_handler(&self, id: HandlerIdentifier) {
+        self.parser.unregister_event_handler(id);
+    }
+
+    pub fn unregister_net_message_handler(&self, id: HandlerIdentifier) {
+        self.parser.unregister_net_message_handler(id);
+    }
+
+    pub fn game_state(&self) -> &demoinfocs_rs::game_state::GameState {
+        self.parser.game_state()
+    }
+}
+
+impl Default for MockParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -8,7 +8,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 - [ ] **Net message handling** – map all message types from `net_messages.go` and expose registration callbacks.
 - [x] **Encrypted net messages** – initial decryption helpers and error handling implemented.
 - [x] **Parser configuration** – complete all options found in the Go `ParserConfig`.
-- [ ] **Mock parser** – reimplement the `fake` package for unit testing.
+- [x] **Mock parser** – reimplement the `fake` package for unit testing.
 
 ## Game State and Entities
 - [ ] **Complete entity tracking** – add Source 1 entity tables and finish the Source 2 implementation (projectile ownership, dropped weapons, etc.).


### PR DESCRIPTION
## Summary
- implement a lightweight `MockParser` for unit tests
- rewrite tests to use the mock parser instead of demo files
- check off fake parser status in `PORTING_STATUS.md`

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6868aa5aa0988326b1cba7e47a183abc