### PR TITLE
Implement player helper methods

### DIFF
--- a/demoinfocs-rs/examples/entities.rs
+++ b/demoinfocs-rs/examples/entities.rs
@@ -25,4 +25,17 @@ fn main() {
     for class in parser.server_classes() {
         println!("ServerClass: id={} name={}", class.id(), class.name());
     }
+
+    parser.parse_to_end().expect("parse error");
+
+    println!("\nPlayers:");
+    for player in parser.game_state().participants().connected() {
+        println!(
+            "{} scoped={} ducking={} bomb_zone={}",
+            player.name,
+            player.is_scoped(),
+            player.is_ducking(),
+            player.is_in_bomb_zone()
+        );
+    }
 }

--- a/demoinfocs-rs/src/common/player.rs
+++ b/demoinfocs-rs/src/common/player.rs
@@ -172,4 +172,44 @@ impl Player {
             .map(|v| v.bool_val())
             .unwrap_or(false)
     }
+
+    pub fn is_in_bomb_zone(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_bInBombZone"))
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn is_ducking(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_bDucking"))
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn is_scoped(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_bIsScoped"))
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn is_spotted_by(&self, other: &Player) -> bool {
+        let spotter_idx = other.entity_id as usize;
+        self.entity
+            .as_ref()
+            .and_then(|e| {
+                let idx = spotter_idx / 32;
+                let prop = format!("m_bSpottedByMask.{:03}", idx);
+                e.property_value(&prop)
+            })
+            .map(|v| {
+                let mask = v.int_val as u32;
+                (mask & (1 << (spotter_idx % 32))) != 0
+            })
+            .unwrap_or(false)
+    }
 }

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -12,7 +12,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 
 ## Game State and Entities
 - [ ] **Complete entity tracking** – add Source 1 entity tables and finish the Source 2 implementation (projectile ownership, dropped weapons, etc.).
-- [ ] **Full `Player` API** – port remaining helper methods (`IsInBombZone`, `IsDucking`, `IsScoped`, `IsSpottedBy`, etc.).
+ - [ ] **Full `Player` API** – basic helpers like `is_in_bomb_zone`, `is_ducking`, `is_scoped` and `is_spotted_by` implemented; more functions pending.
 - [ ] **Inferno and grenade helpers** – replicate convex hull calculations and trajectory tracking from `inferno.go` and `grenade.go`.
 - [ ] **Game rules and match info** – implement the structures and callbacks from `gamerules.go` and `matchinfo.go`.
 - [ ] **String table based equipment mapping** – parse item definitions for accurate equipment types.


### PR DESCRIPTION
## Summary
- add helper methods like `is_in_bomb_zone`, `is_ducking`, `is_scoped` and `is_spotted_by`
- show player helper usage in the `entities` example
- note progress on player API in porting status docs

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- demoinfocs-rs/examples/entities.rs demoinfocs-rs/src/common/player.rs`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml -q`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6868aa7fa45c8326a8bc91dff1a2847c