### PR TITLE
Add inferno hull utilities and grenade tracking

### DIFF
--- a/demoinfocs-rs/src/common/grenade.rs
+++ b/demoinfocs-rs/src/common/grenade.rs
@@ -1,5 +1,6 @@
 use super::{Equipment, Player};
-use crate::sendtables::entity::{Entity, Vector};
+use crate::sendtables2::Entity;
+use crate::sendtables::entity::Vector;
 use std::time::Duration;
 
 #[derive(Default)]
@@ -28,5 +29,24 @@ pub fn new_grenade_projectile() -> GrenadeProjectile {
     GrenadeProjectile {
         unique_id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
         ..Default::default()
+    }
+}
+
+impl GrenadeProjectile {
+    /// Record a new position for the projectile. The point is appended to both
+    /// trajectory vectors, storing the frame and time for more detailed
+    /// analysis.
+    pub fn track_position(&mut self, position: Vector, frame_id: i32, time: Duration) {
+        self.trajectory.push(position.clone());
+        self.trajectory2.push(TrajectoryEntry {
+            position,
+            frame_id,
+            time,
+        });
+    }
+
+    /// Returns the last tracked position if any.
+    pub fn last_position(&self) -> Option<&Vector> {
+        self.trajectory.last()
     }
 }

--- a/demoinfocs-rs/src/common/inferno.rs
+++ b/demoinfocs-rs/src/common/inferno.rs
@@ -1,13 +1,74 @@
-use crate::sendtables::entity::{Entity, Vector};
+use crate::sendtables2::Entity;
+use crate::sendtables::entity::Vector;
 
-#[derive(Default)]
+/// Representation of an active inferno (molotov/incendiary flames).
+#[derive(Default, Clone)]
 pub struct Inferno {
+    /// Underlying entity for the inferno if available.
     pub entity: Option<Entity>,
+    /// Individual flame origins gathered from the entity properties.
+    pub flames: Vec<Vector>,
+    /// Cached convex hull around all flames in `flames`.
+    pub hull: Vec<Vector>,
 }
 
 impl Inferno {
-    pub fn position(&self) -> Vector {
-        let _ = &self.entity;
-        Vector::default()
+    /// Updates the convex hull from the currently stored flames.
+    pub fn update_hull(&mut self) {
+        self.hull = convex_hull(&self.flames);
     }
+
+    /// Returns the precalculated convex hull points.
+    pub fn hull(&self) -> &[Vector] {
+        &self.hull
+    }
+}
+
+/// Calculates the convex hull of a set of 2D points using the monotone chain
+/// algorithm. `Vector::z` is ignored.
+pub fn convex_hull(points: &[Vector]) -> Vec<Vector> {
+    let mut pts = points.to_vec();
+    if pts.len() <= 1 {
+        return pts;
+    }
+
+    pts.sort_by(|a, b| {
+        match a.x.partial_cmp(&b.x) {
+            Some(core::cmp::Ordering::Equal) => a
+                .y
+                .partial_cmp(&b.y)
+                .unwrap_or(core::cmp::Ordering::Equal),
+            Some(o) => o,
+            None => core::cmp::Ordering::Equal,
+        }
+    });
+
+    let mut lower: Vec<Vector> = Vec::new();
+    for p in &pts {
+        while lower.len() >= 2
+            && cross(&lower[lower.len() - 2], &lower[lower.len() - 1], p) <= 0.0
+        {
+            lower.pop();
+        }
+        lower.push(p.clone());
+    }
+
+    let mut upper: Vec<Vector> = Vec::new();
+    for p in pts.iter().rev() {
+        while upper.len() >= 2
+            && cross(&upper[upper.len() - 2], &upper[upper.len() - 1], p) <= 0.0
+        {
+            upper.pop();
+        }
+        upper.push(p.clone());
+    }
+
+    lower.pop();
+    upper.pop();
+    lower.extend(upper);
+    lower
+}
+
+fn cross(o: &Vector, a: &Vector, b: &Vector) -> f64 {
+    (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x)
 }

--- a/demoinfocs-rs/tests/common_inferno.rs
+++ b/demoinfocs-rs/tests/common_inferno.rs
@@ -1,0 +1,15 @@
+use demoinfocs_rs::common::convex_hull;
+use demoinfocs_rs::sendtables::entity::Vector;
+
+#[test]
+fn convex_hull_basic() {
+    let points = vec![
+        Vector { x: 0.0, y: 0.0, z: 0.0 },
+        Vector { x: 1.0, y: 0.0, z: 0.0 },
+        Vector { x: 1.0, y: 1.0, z: 0.0 },
+        Vector { x: 0.0, y: 1.0, z: 0.0 },
+        Vector { x: 0.5, y: 0.5, z: 0.0 },
+    ];
+    let hull = convex_hull(&points);
+    assert_eq!(4, hull.len());
+}

--- a/demoinfocs-rs/tests/game_state_grenade.rs
+++ b/demoinfocs-rs/tests/game_state_grenade.rs
@@ -1,0 +1,25 @@
+use demoinfocs_rs::parser::{Parser, EntityEvent};
+use demoinfocs_rs::sendtables::EntityOp;
+use demoinfocs_rs::sendtables2::{Class, Entity};
+use std::io::Cursor;
+
+#[test]
+fn track_active_grenades_and_infernos() {
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+
+    let g_class = Class { class_id: 1, name: "CSmokeGrenadeProjectile".into(), serializer: None };
+    let grenade = Entity { index: 1, serial: 1, class: g_class };
+    parser.dispatch_event(EntityEvent { entity: grenade.clone(), op: EntityOp::CREATED });
+    assert_eq!(1, parser.game_state().grenade_projectiles().len());
+
+    parser.dispatch_event(EntityEvent { entity: grenade, op: EntityOp::DELETED });
+    assert_eq!(0, parser.game_state().grenade_projectiles().len());
+
+    let i_class = Class { class_id: 2, name: "CInferno".into(), serializer: None };
+    let inferno = Entity { index: 2, serial: 1, class: i_class };
+    parser.dispatch_event(EntityEvent { entity: inferno.clone(), op: EntityOp::CREATED });
+    assert_eq!(1, parser.game_state().infernos().len());
+
+    parser.dispatch_event(EntityEvent { entity: inferno, op: EntityOp::DELETED });
+    assert_eq!(0, parser.game_state().infernos().len());
+}

--- a/demoinfocs-rs/tests/grenade_trajectory.rs
+++ b/demoinfocs-rs/tests/grenade_trajectory.rs
@@ -1,0 +1,14 @@
+use demoinfocs_rs::common::{new_grenade_projectile, GrenadeProjectile};
+use demoinfocs_rs::sendtables::entity::Vector;
+use std::time::Duration;
+
+#[test]
+fn projectile_tracks_positions() {
+    let mut g = new_grenade_projectile();
+    g.track_position(Vector { x: 0.0, y: 0.0, z: 0.0 }, 1, Duration::from_millis(1));
+    g.track_position(Vector { x: 1.0, y: 1.0, z: 0.0 }, 2, Duration::from_millis(2));
+    assert_eq!(2, g.trajectory.len());
+    assert_eq!(Some(&Vector { x: 1.0, y: 1.0, z: 0.0 }), g.last_position());
+    assert_eq!(2, g.trajectory2.len());
+    assert_eq!(2, g.trajectory2[1].frame_id);
+}


### PR DESCRIPTION
## Summary
- implement convex hull logic for infernos
- add projectile trajectory helpers
- track grenade and inferno entities in GameState
- expose active grenades/infernos
- test hull computation, projectile tracking, and entity handling

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo build --manifest-path demoinfocs-rs/Cargo.toml --examples`

------
https://chatgpt.com/codex/tasks/task_e_6868b9c1629483268c5266749517cc51