### PR TITLE
Add GameRules module and match settings support

### DIFF
--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -1,3 +1,4 @@
+pub use crate::gamerules::GamePhase;
 use crate::proto::msgs2::csvc_msg_game_event;
 use crate::sendtables::entity::Vector;
 
@@ -28,7 +29,6 @@ pub struct PlayerInfoData;
 pub type EquipmentType = u32;
 pub type Team = u8;
 pub type HostageState = u32;
-pub type GamePhase = u8;
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]

--- a/demoinfocs-rs/src/game_state.rs
+++ b/demoinfocs-rs/src/game_state.rs
@@ -49,6 +49,7 @@ impl<'a> Participants<'a> {
 #[derive(Clone, Default)]
 pub struct GameRules {
     pub con_vars: HashMap<String, String>,
+    pub entity: Option<Entity>,
 }
 
 #[derive(Default)]
@@ -188,6 +189,34 @@ impl GameState {
         &self.rules
     }
 
+    pub fn match_settings(&self) -> &std::collections::HashMap<String, String> {
+        &self.rules.con_vars
+    }
+
+    pub fn round_time(&self) -> Option<std::time::Duration> {
+        self.rules
+            .con_vars
+            .get("mp_roundtime")
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(std::time::Duration::from_secs)
+    }
+
+    pub fn freeze_time(&self) -> Option<std::time::Duration> {
+        self.rules
+            .con_vars
+            .get("mp_freezetime")
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(std::time::Duration::from_secs)
+    }
+
+    pub fn bomb_time(&self) -> Option<std::time::Duration> {
+        self.rules
+            .con_vars
+            .get("mp_c4timer")
+            .and_then(|v| v.parse::<u64>().ok())
+            .map(std::time::Duration::from_secs)
+    }
+
     pub fn ingame_tick(&self) -> i32 {
         self.ingame_tick
     }
@@ -209,7 +238,11 @@ impl GameState {
         if name.contains("Projectile") {
             self.projectile_owners.entry(ent.index).or_insert(0);
         } else if name.contains("DroppedWeapon") || name.contains("Dropped") {
-            self.dropped_weapons.entry(ent.index).or_insert_with(|| name.to_string());
+            self.dropped_weapons
+                .entry(ent.index)
+                .or_insert_with(|| name.to_string());
+        } else if name.contains("GameRules") {
+            self.rules.entity = Some(ent.clone());
         }
     }
 

--- a/demoinfocs-rs/src/gamerules.rs
+++ b/demoinfocs-rs/src/gamerules.rs
@@ -1,0 +1,37 @@
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum GamePhase {
+    Init = 0,
+    Pregame = 1,
+    StartGamePhase = 2,
+    TeamSideSwitch = 3,
+    GameHalfEnded = 4,
+    GameEnded = 5,
+    StaleMate = 6,
+    GameOver = 7,
+}
+
+impl Default for GamePhase {
+    fn default() -> Self {
+        GamePhase::Init
+    }
+}
+
+impl std::fmt::Display for GamePhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                | GamePhase::Init => "Init",
+                | GamePhase::Pregame => "Pregame",
+                | GamePhase::StartGamePhase => "Start game phase",
+                | GamePhase::TeamSideSwitch => "Team side switch",
+                | GamePhase::GameHalfEnded => "Game half ended",
+                | GamePhase::GameEnded => "Game ended",
+                | GamePhase::StaleMate => "StaleMate",
+                | GamePhase::GameOver => "GameOver",
+            }
+        )
+    }
+}

--- a/demoinfocs-rs/src/lib.rs
+++ b/demoinfocs-rs/src/lib.rs
@@ -5,6 +5,7 @@ pub mod dispatcher;
 pub mod events;
 pub mod game_events;
 pub mod game_state;
+pub mod gamerules;
 pub mod matchinfo;
 pub mod parser;
 pub mod proto;

--- a/demoinfocs-rs/src/parser/mod.rs
+++ b/demoinfocs-rs/src/parser/mod.rs
@@ -573,172 +573,197 @@ impl<R: Read> Parser<R> {
     }
 
     fn handle_svc_message(&mut self, msg_type: u32, buf: &[u8]) {
-        match std::convert::TryFrom::try_from(msg_type as i32).ok() {
-            | Some(proto_msg::SvcMessages::SvcServerInfo) => {
-                if let Ok(msg) = proto_msg::CsvcMsgServerInfo::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcSendTable) => {
-                if let Ok(msg) = proto_msg::CsvcMsgSendTable::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcClassInfo) => {
-                if let Ok(msg) = proto_msg::CsvcMsgClassInfo::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcSetPause) => {
-                if let Ok(msg) = proto_msg::CsvcMsgSetPause::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcCreateStringTable) => {
-                if let Ok(msg) = proto_msg::CsvcMsgCreateStringTable::decode(&buf[..]) {
-                    if let Some(t) = self.string_tables.on_create_string_table(&msg) {
-                        self.dispatch_event(StringTableUpdated { table: t });
+        if let Ok(kind) = proto_msg::SvcMessages::try_from(msg_type as i32) {
+            match kind {
+                | proto_msg::SvcMessages::SvcServerInfo => {
+                    if let Ok(msg) = proto_msg::CsvcMsgServerInfo::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
                     }
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcUpdateStringTable) => {
-                if let Ok(msg) = proto_msg::CsvcMsgUpdateStringTable::decode(&buf[..]) {
-                    if let Some(t) = self.string_tables.on_update_string_table(&msg) {
-                        self.dispatch_event(StringTableUpdated { table: t });
+                },
+                | proto_msg::SvcMessages::SvcSendTable => {
+                    if let Ok(msg) = proto_msg::CsvcMsgSendTable::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
                     }
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcVoiceInit) => {
-                if let Ok(msg) = proto_msg::CsvcMsgVoiceInit::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcVoiceData) => {
-                if let Ok(msg) = proto_msg::CsvcMsgVoiceData::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcPrint) => {
-                if let Ok(msg) = proto_msg::CsvcMsgPrint::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcSounds) => {
-                if let Ok(msg) = proto_msg::CsvcMsgSounds::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcSetView) => {
-                if let Ok(msg) = proto_msg::CsvcMsgSetView::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcFixAngle) => {
-                if let Ok(msg) = proto_msg::CsvcMsgFixAngle::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcCrosshairAngle) => {
-                if let Ok(msg) = proto_msg::CsvcMsgCrosshairAngle::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcBspDecal) => {
-                if let Ok(msg) = proto_msg::CsvcMsgBspDecal::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcSplitScreen) => {
-                if let Ok(msg) = proto_msg::CsvcMsgSplitScreen::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcUserMessage) => {
-                if let Ok(msg) = proto_msg::CsvcMsgUserMessage::decode(&buf[..]) {
-                    self.handle_user_message(&msg);
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcEntityMessage) => {
-                if let Ok(msg) = proto_msg::CsvcMsgEntityMsg::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcGameEvent) => {
-                if let Ok(msg) = proto_msg::CsvcMsgGameEvent::decode(&buf[..]) {
-                    self.on_game_event(&msg);
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcPacketEntities) => {
-                if let Ok(msg) = proto_msg::CsvcMsgPacketEntities::decode(&buf[..]) {
-                    for (ent, op) in self.s2_tables.parse_packet_entities(&msg) {
-                        let ev = EntityEvent {
-                            entity: ent.clone(),
-                            op,
-                        };
-                        self.dispatch_event(ev.clone());
-                        if op.contains(crate::sendtables::EntityOp::CREATED) {
-                            self.dispatch_event(EntityCreated { entity: ent });
+                },
+                | proto_msg::SvcMessages::SvcClassInfo => {
+                    if let Ok(msg) = proto_msg::CsvcMsgClassInfo::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcSetPause => {
+                    if let Ok(msg) = proto_msg::CsvcMsgSetPause::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcCreateStringTable => {
+                    if let Ok(msg) = proto_msg::CsvcMsgCreateStringTable::decode(&buf[..]) {
+                        if let Some(t) = self.string_tables.on_create_string_table(&msg) {
+                            self.dispatch_event(StringTableUpdated { table: t });
                         }
+                        self.dispatch_net_message(msg);
                     }
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcTempEntities) => {
-                if let Ok(msg) = proto_msg::CsvcMsgTempEntities::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcPrefetch) => {
-                if let Ok(msg) = proto_msg::CsvcMsgPrefetch::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcMenu) => {
-                if let Ok(msg) = proto_msg::CsvcMsgMenu::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcGameEventList) => {
-                if let Ok(msg) = proto_msg::CsvcMsgGameEventList::decode(&buf[..]) {
-                    self.on_game_event_list(&msg);
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcGetCvarValue) => {
-                if let Ok(msg) = proto_msg::CsvcMsgGetCvarValue::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcPaintmapData) => {
-                if let Ok(msg) = proto_msg::CsvcMsgPaintmapData::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcCmdKeyValues) => {
-                if let Ok(msg) = proto_msg::CsvcMsgCmdKeyValues::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcEncryptedData) => {
-                if let Ok(msg) = proto_msg::CsvcMsgEncryptedData::decode(&buf[..]) {
-                    self.handle_encrypted_data(&msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcHltvReplay) => {
-                if let Ok(msg) = proto_msg::CsvcMsgHltvReplay::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | Some(proto_msg::SvcMessages::SvcBroadcastCommand) => {
-                if let Ok(msg) = proto_msg::CsvcMsgBroadcastCommand::decode(&buf[..]) {
-                    self.dispatch_net_message(msg);
-                }
-            },
-            | _ => {},
+                },
+                | proto_msg::SvcMessages::SvcUpdateStringTable => {
+                    if let Ok(msg) = proto_msg::CsvcMsgUpdateStringTable::decode(&buf[..]) {
+                        if let Some(t) = self.string_tables.on_update_string_table(&msg) {
+                            self.dispatch_event(StringTableUpdated { table: t });
+                        }
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcVoiceInit => {
+                    if let Ok(msg) = proto_msg::CsvcMsgVoiceInit::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcVoiceData => {
+                    if let Ok(msg) = proto_msg::CsvcMsgVoiceData::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcPrint => {
+                    if let Ok(msg) = proto_msg::CsvcMsgPrint::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcSounds => {
+                    if let Ok(msg) = proto_msg::CsvcMsgSounds::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcSetView => {
+                    if let Ok(msg) = proto_msg::CsvcMsgSetView::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcFixAngle => {
+                    if let Ok(msg) = proto_msg::CsvcMsgFixAngle::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcCrosshairAngle => {
+                    if let Ok(msg) = proto_msg::CsvcMsgCrosshairAngle::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcBspDecal => {
+                    if let Ok(msg) = proto_msg::CsvcMsgBspDecal::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcSplitScreen => {
+                    if let Ok(msg) = proto_msg::CsvcMsgSplitScreen::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcUserMessage => {
+                    if let Ok(msg) = proto_msg::CsvcMsgUserMessage::decode(&buf[..]) {
+                        self.handle_user_message(&msg);
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcEntityMessage => {
+                    if let Ok(msg) = proto_msg::CsvcMsgEntityMsg::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcGameEvent => {
+                    if let Ok(msg) = proto_msg::CsvcMsgGameEvent::decode(&buf[..]) {
+                        self.on_game_event(&msg);
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcPacketEntities => {
+                    if let Ok(msg) = proto_msg::CsvcMsgPacketEntities::decode(&buf[..]) {
+                        for (ent, op) in self.s2_tables.parse_packet_entities(&msg) {
+                            let ev = EntityEvent {
+                                entity: ent.clone(),
+                                op,
+                            };
+                            self.dispatch_event(ev.clone());
+                            if op.contains(crate::sendtables::EntityOp::CREATED) {
+                                self.dispatch_event(EntityCreated { entity: ent });
+                            }
+                        }
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcTempEntities => {
+                    if let Ok(msg) = proto_msg::CsvcMsgTempEntities::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcPrefetch => {
+                    if let Ok(msg) = proto_msg::CsvcMsgPrefetch::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcMenu => {
+                    if let Ok(msg) = proto_msg::CsvcMsgMenu::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcGameEventList => {
+                    if let Ok(msg) = proto_msg::CsvcMsgGameEventList::decode(&buf[..]) {
+                        self.on_game_event_list(&msg);
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcGetCvarValue => {
+                    if let Ok(msg) = proto_msg::CsvcMsgGetCvarValue::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcPaintmapData => {
+                    if let Ok(msg) = proto_msg::CsvcMsgPaintmapData::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcCmdKeyValues => {
+                    if let Ok(msg) = proto_msg::CsvcMsgCmdKeyValues::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcEncryptedData => {
+                    if let Ok(msg) = proto_msg::CsvcMsgEncryptedData::decode(&buf[..]) {
+                        self.handle_encrypted_data(&msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcHltvReplay => {
+                    if let Ok(msg) = proto_msg::CsvcMsgHltvReplay::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | proto_msg::SvcMessages::SvcBroadcastCommand => {
+                    if let Ok(msg) = proto_msg::CsvcMsgBroadcastCommand::decode(&buf[..]) {
+                        self.dispatch_net_message(msg);
+                    }
+                },
+            }
+        } else if let Ok(net) = proto_msg::NetMessages::try_from(msg_type as i32) {
+            match net {
+                | proto_msg::NetMessages::NetSetConVar => {
+                    if let Ok(msg) = proto_msg::CnetMsgSetConVar::decode(&buf[..]) {
+                        if let Some(ref cvars) = msg.convars {
+                            let mut map = HashMap::new();
+                            for cv in &cvars.cvars {
+                                if let (Some(name), Some(value)) =
+                                    (cv.name.clone(), cv.value.clone())
+                                {
+                                    map.insert(name, value);
+                                }
+                            }
+                            if !map.is_empty() {
+                                self.dispatch_event(crate::events::ConVarsUpdated {
+                                    updated_con_vars: map.clone(),
+                                });
+                            }
+                        }
+                        self.dispatch_net_message(msg);
+                    }
+                },
+                | _ => {},
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement `gamerules` module with `GamePhase` enum
- parse `NET_SetConVar` and update game rules
- expose match settings and rule helpers in `GameState`
- hook into entity creation to track GameRules entity

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml -q`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6868b9c53cbc832681bbe1c9b3e89538