### PR TITLE
Add equipment mapping from item definition tables

### DIFF
--- a/demoinfocs-rs/src/parser/datatable.rs
+++ b/demoinfocs-rs/src/parser/datatable.rs
@@ -2,10 +2,66 @@ use std::collections::HashMap;
 
 use crate::common::{EquipmentType, map_equipment};
 use crate::sendtables1::serverclass::ServerClass;
+use crate::stringtables::StringTable;
+
+fn normalize_item_name(name: &str) -> String {
+    let mut n = name.to_lowercase();
+    if let Some(stripped) = n.strip_prefix("weapon_") {
+        n = stripped.to_string();
+    }
+    n
+}
+
+fn equipment_from_table(table: &StringTable) -> Vec<(String, EquipmentType)> {
+    table
+        .entries
+        .values()
+        .filter_map(|e| {
+            let raw = if !e.value.is_empty() {
+                e.value.clone()
+            } else if !e.user_data.is_empty() {
+                String::from_utf8_lossy(&e.user_data).into_owned()
+            } else {
+                return None;
+            };
+            let name = normalize_item_name(&raw);
+            let typ = map_equipment(&name);
+            if typ == EquipmentType::Unknown {
+                None
+            } else {
+                Some((name, typ))
+            }
+        })
+        .collect()
+}
 
 /// Build a mapping from server class names to [`EquipmentType`].
-pub fn build_equipment_mapping(classes: &[ServerClass]) -> HashMap<String, EquipmentType> {
+pub fn build_equipment_mapping(
+    classes: &[ServerClass],
+    item_defs: Option<&StringTable>,
+) -> HashMap<String, EquipmentType> {
     let mut out = HashMap::new();
+
+    if let Some(tbl) = item_defs {
+        let names = equipment_from_table(tbl);
+        if !names.is_empty() {
+            for sc in classes {
+                let name_lower = sc.name.to_lowercase();
+                let dt_lower = sc.data_table_name.to_lowercase();
+                for (item, eq) in &names {
+                    if name_lower.contains(item) || dt_lower.contains(item) {
+                        out.insert(sc.name.clone(), *eq);
+                        break;
+                    }
+                }
+            }
+            if !out.is_empty() {
+                return out;
+            }
+        }
+    }
+
+    // fallback heuristics
     for sc in classes {
         let name = sc.name.clone();
         if name == "CC4" {

--- a/demoinfocs-rs/src/parser/mod.rs
+++ b/demoinfocs-rs/src/parser/mod.rs
@@ -212,7 +212,9 @@ impl<R: Read> Parser<R> {
     }
 
     fn update_equipment_mapping_from_classes(&mut self) {
-        self.equipment_mapping = datatable::build_equipment_mapping(&self.server_classes);
+        let item_defs = self.string_tables.get("ItemDefinitions");
+        self.equipment_mapping =
+            datatable::build_equipment_mapping(&self.server_classes, item_defs);
         self.game_state.equipment_mapping = self.equipment_mapping.clone();
     }
 

--- a/demoinfocs-rs/tests/equipment.rs
+++ b/demoinfocs-rs/tests/equipment.rs
@@ -1,6 +1,7 @@
 use demoinfocs_rs::common::{EquipmentType, map_equipment};
 use demoinfocs_rs::parser::datatable::build_equipment_mapping;
 use demoinfocs_rs::sendtables::serverclass::ServerClass;
+use demoinfocs_rs::stringtables::{StringTable, StringTableEntry};
 
 #[test]
 fn test_map_equipment_basic() {
@@ -35,11 +36,53 @@ fn test_build_equipment_mapping() {
         data_table_name: "DT_SmokeGrenadeProjectile".into(),
         ..Default::default()
     };
-    let map = build_equipment_mapping(&[sc1, sc2, sc3]);
+    let map = build_equipment_mapping(&[sc1, sc2, sc3], None);
     assert_eq!(Some(&EquipmentType::Bomb), map.get("CC4"));
     assert_eq!(Some(&EquipmentType::Ak47), map.get("CWeaponAK47"));
     assert_eq!(
         Some(&EquipmentType::Smoke),
         map.get("CSmokeGrenadeProjectile")
     );
+}
+
+#[test]
+fn test_build_equipment_mapping_itemdefs() {
+    let sc1 = ServerClass {
+        id: 1,
+        name: "CWeaponAK47".into(),
+        data_table_id: 0,
+        data_table_name: "DT_WeaponAK47".into(),
+        ..Default::default()
+    };
+    let sc2 = ServerClass {
+        id: 2,
+        name: "CSmokeGrenadeProjectile".into(),
+        data_table_id: 0,
+        data_table_name: "DT_SmokeGrenadeProjectile".into(),
+        ..Default::default()
+    };
+
+    let mut tbl = StringTable {
+        name: "ItemDefinitions".into(),
+        ..Default::default()
+    };
+    tbl.entries.insert(
+        0,
+        StringTableEntry {
+            value: "weapon_ak47".into(),
+            user_data: Vec::new(),
+        },
+    );
+    tbl.entries.insert(
+        1,
+        StringTableEntry {
+            value: "smokegrenade".into(),
+            user_data: Vec::new(),
+        },
+    );
+
+    let map = build_equipment_mapping(&[sc1.clone(), sc2.clone()], Some(&tbl));
+
+    assert_eq!(Some(&EquipmentType::Ak47), map.get(&sc1.name));
+    assert_eq!(Some(&EquipmentType::Smoke), map.get(&sc2.name));
 }


### PR DESCRIPTION
## Summary
- parse equipment names from the ItemDefinitions string table
- use parsed data to build equipment mappings if available
- update parser to supply item definition table
- add unit test for item definition mapping

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6868b9c6cfcc8326b43ce5542f84fa1b