### PR TITLE
Implement voice capture example

### DIFF
--- a/demoinfocs-rs/examples/voice_capture.rs
+++ b/demoinfocs-rs/examples/voice_capture.rs
@@ -1,5 +1,65 @@
+use demoinfocs_rs::parser::Parser;
+use demoinfocs_rs::proto::{msg, msgs2};
+use std::env;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::sync::{Arc, Mutex};
+
+fn args() -> (String, String) {
+    let mut args = env::args().skip(1);
+    let mut demo = None;
+    let mut out = String::from("voice.raw");
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            | "-demo" => demo = args.next(),
+            | "-out" => out = args.next().expect("-out requires a path after it"),
+            | _ => {
+                eprintln!("Usage: cargo run --example voice_capture -- -demo <demo> [-out <file>]");
+                std::process::exit(1);
+            },
+        }
+    }
+    let demo = demo.expect("-demo <demo> is required");
+    (demo, out)
+}
+
 fn main() {
-    println!("This example shows how to capture voice data from demos.");
-    println!("For CS2 see https://github.com/DandrewsDev/CS2VoiceData");
-    println!("For CS:GO see https://github.com/saiko-tech/csgo-demo-voice-capture-example");
+    let (demo_path, out_path) = args();
+
+    let file = File::open(&demo_path).expect("failed to open demo file");
+    let mut parser = Parser::new(file);
+
+    let writer = Arc::new(Mutex::new(BufWriter::new(
+        File::create(&out_path).expect("failed to create output file"),
+    )));
+
+    {
+        let writer = Arc::clone(&writer);
+        parser.register_net_message_handler::<msg::CsvcMsgVoiceData, _>(move |msg| {
+            if let Some(data) = msg.voice_data.as_ref() {
+                if let Ok(mut w) = writer.lock() {
+                    let _ = w.write_all(data);
+                }
+            }
+        });
+    }
+
+    {
+        let writer = Arc::clone(&writer);
+        parser.register_net_message_handler::<msgs2::CsvcMsgVoiceData, _>(move |msg| {
+            if let Some(audio) = &msg.audio {
+                if let Some(data) = audio.voice_data.as_ref() {
+                    if let Ok(mut w) = writer.lock() {
+                        let _ = w.write_all(data);
+                    }
+                }
+            }
+        });
+    }
+
+    if let Err(e) = parser.parse_to_end() {
+        eprintln!("error while parsing demo: {:?}", e);
+    }
+
+    println!("voice data written to {}", out_path);
 }

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -25,7 +25,8 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 - [ ] **Round backup and restore** – support messages such as `CS_UM_RoundBackupFilenames` and `CS_UM_RoundImpactScoreData` with full data models.
 
 ## Examples and Utilities
-- [ ] **Voice capture example** – finish the example in `examples/voice-capture` once voice data parsing is implemented.
+- [x] **Voice capture example** – implemented using `Parser::register_net_message_handler`.
+  Run `cargo run --example voice_capture -- -demo <demo> -out voice.raw` to dump the raw audio stream.
 - [ ] **WebAssembly bindings** – port the old WASM example and ensure the crate builds for `wasm32-unknown-unknown`.
 - [ ] **Parallel processing** – reintroduce the parallel parsing utilities for batch processing multiple demos.
 - [ ] **Command helpers** – port the `s2_commands.go` helpers for crafting demo commands.

--- a/examples/voice-capture/README.md
+++ b/examples/voice-capture/README.md
@@ -1,12 +1,15 @@
 # Capturing Voice Data
 
-## CS2
+This example extracts the in‑game voice chat from a demo and saves the raw audio
+payloads to disk. Run it from the repository root:
 
-See https://github.com/DandrewsDev/CS2VoiceData
+```bash
+cargo run --example voice_capture -- -demo <path/to/demo.dem> -out voice.raw
+```
 
-## CS:GO
+The written file contains the encoded voice stream. Converting the audio to a
+playable format depends on the game and may require external tools. More details
+can be found in the following projects:
 
-This example shows how to use the library to capture voice audio from demos.
-
-Since the build process is somewhat different from the library itself (due to usage of CGO), the example has it's own repository which you can find here:
-https://github.com/saiko-tech/csgo-demo-voice-capture-example
+- CS2: <https://github.com/DandrewsDev/CS2VoiceData>
+- CS:GO: <https://github.com/saiko-tech/csgo-demo-voice-capture-example>


### PR DESCRIPTION
## Summary
- implement real voice capture example using net message handlers
- write captured bytes to disk
- show how to run the example in README
- mark the example as completed in PORTING_STATUS

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6868d01b3de08326bf40ccf74cc02bc4