### PR TITLE
Add parallel processing helpers

### DIFF
--- a/demoinfocs-rs/Cargo.toml
+++ b/demoinfocs-rs/Cargo.toml
@@ -11,6 +11,7 @@ crossbeam-channel = "0.5"
 bitflags = "2.9"
 once_cell = "1.21"
 ice-crypt = "1.0"
+rayon = "1.10"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/demoinfocs-rs/examples/parallel.rs
+++ b/demoinfocs-rs/examples/parallel.rs
@@ -1,0 +1,25 @@
+use demoinfocs_rs::utils::parallel;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let dir = env::args()
+        .nth(1)
+        .expect("Usage: cargo run --example parallel -- <demo-directory>");
+    let demos: Vec<PathBuf> = fs::read_dir(dir)
+        .expect("failed to read directory")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().map(|e| e == "dem").unwrap_or(false))
+        .collect();
+
+    parallel::run(demos, |parser, path| {
+        if let Ok(header) = parser.parse_header() {
+            println!("{} -> {}", path.display(), header.map_name);
+        }
+        if let Err(e) = parser.parse_to_end() {
+            eprintln!("{}: {:?}", path.display(), e);
+        }
+    });
+}

--- a/demoinfocs-rs/src/utils/mod.rs
+++ b/demoinfocs-rs/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod net_encryption;
+pub mod parallel;
 mod steamid;
 
 pub use steamid::*;

--- a/demoinfocs-rs/src/utils/parallel.rs
+++ b/demoinfocs-rs/src/utils/parallel.rs
@@ -1,0 +1,24 @@
+use rayon::prelude::*;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use crate::parser::Parser;
+
+/// Runs the given function for every demo path in parallel.
+///
+/// The closure receives a mutable [`Parser`] for the demo file and the path
+/// to the file. Any parsing work (such as calling [`Parser::parse_to_end`])
+/// is left to the closure.
+pub fn run<I, P, F>(paths: I, func: F)
+where
+    I: IntoParallelIterator<Item = P>,
+    P: Into<PathBuf> + Send,
+    F: Fn(&mut Parser<File>, &Path) + Send + Sync,
+{
+    paths.into_par_iter().for_each(|p| {
+        let path: PathBuf = p.into();
+        let file = File::open(&path).expect("failed to open demo file");
+        let mut parser = Parser::new(file);
+        func(&mut parser, &path);
+    });
+}

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -17,7 +17,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 
 - [ ] **Inferno and grenade helpers** – replicate convex hull calculations and trajectory tracking from `inferno.go` and `grenade.go`.
 - [ ] **Game rules and match info** – implement the structures and callbacks from `gamerules.go` and `matchinfo.go`.
-- [ ] **String table based equipment mapping** – parse item definitions for accurate equipment types.
+- [x] **String table based equipment mapping** – parse item definitions for accurate equipment types.
 
 ## Events and Messages
 - [ ] **All game events** – many event structs exist but not every event from `game_events.go` is decoded. Ensure every event descriptor is represented and dispatched.
@@ -27,7 +27,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 ## Examples and Utilities
 - [ ] **Voice capture example** – finish the example in `examples/voice-capture` once voice data parsing is implemented.
 - [ ] **WebAssembly bindings** – port the old WASM example and ensure the crate builds for `wasm32-unknown-unknown`.
-- [ ] **Parallel processing** – reintroduce the parallel parsing utilities for batch processing multiple demos.
+- [x] **Parallel processing** – reintroduce the parallel parsing utilities for batch processing multiple demos.
 - [ ] **Command helpers** – port the `s2_commands.go` helpers for crafting demo commands.
 
 This checklist is meant as guidance for achieving feature parity with the old Go library. As functionality is added, update this document to track remaining work.

--- a/docs/parallel-processing.puml
+++ b/docs/parallel-processing.puml
@@ -3,6 +3,11 @@ participant Consumer
 participant Parser
 participant Queue
 
+note over Consumer, Parser
+Multiple demos can be processed concurrently using
+`utils::parallel::run` together with Rayon.
+end note
+
 Consumer ++
 Consumer -> Parser ++: ParseToEnd
 par


### PR DESCRIPTION
## Summary
- add rayon dependency
- expose utils::parallel for concurrent demo parsing
- show rayon usage in a new parallel example
- update parallel-processing diagram notes
- mark completed tasks in PORTING_STATUS

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6868d031f8dc8326b7bf88dd8438585b