### PR TITLE
Add command builder for Source2 packets

### DIFF
--- a/demoinfocs-rs/src/commands.rs
+++ b/demoinfocs-rs/src/commands.rs
@@ -1,0 +1,69 @@
+// Utilities for crafting Source 2 demo commands
+use bitstream_io::{BitWrite, BitWriter, LittleEndian};
+use prost::Message;
+
+use crate::proto::msgs2::{CDemoPacket, NetMessages};
+
+fn write_ubit_int<W: std::io::Write>(writer: &mut BitWriter<W, LittleEndian>, value: u32) -> std::io::Result<()> {
+    let lower = value & 0xF;
+    let high = value >> 4;
+    if high == 0 {
+        writer.write(6, lower)?;
+    } else if high < (1 << 4) {
+        writer.write(6, lower | 0x10)?;
+        writer.write(4, high)?;
+    } else if high < (1 << 8) {
+        writer.write(6, lower | 0x20)?;
+        writer.write(8, high)?;
+    } else {
+        writer.write(6, lower | 0x30)?;
+        writer.write(28, high)?;
+    }
+    Ok(())
+}
+
+fn write_varint32<W: std::io::Write>(writer: &mut BitWriter<W, LittleEndian>, mut value: u32) -> std::io::Result<()> {
+    writer.byte_align();
+    loop {
+        let mut b = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            b |= 0x80;
+        }
+        writer.write(8, b as u32)?;
+        if value == 0 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Builder for creating [`CDemoPacket`] messages from net messages.
+pub struct CommandBuilder {
+    writer: BitWriter<Vec<u8>, LittleEndian>,
+}
+
+impl CommandBuilder {
+    /// Create a new empty builder.
+    pub fn new() -> Self {
+        Self { writer: BitWriter::endian(Vec::new(), LittleEndian) }
+    }
+
+    /// Append a Source 2 net message.
+    pub fn push_net_message<M: Message>(&mut self, ty: NetMessages, msg: &M) -> std::io::Result<()> {
+        write_ubit_int(&mut self.writer, ty as u32)?;
+        let buf = msg.encode_to_vec();
+        write_varint32(&mut self.writer, buf.len() as u32)?;
+        self.writer.byte_align();
+        for b in buf {
+            self.writer.write(8, b as u32)?;
+        }
+        Ok(())
+    }
+
+    /// Finish building and return the [`CDemoPacket`].
+    pub fn into_packet(mut self) -> CDemoPacket {
+        self.writer.byte_align();
+        CDemoPacket { data: Some(self.writer.into_writer()) }
+    }
+}

--- a/demoinfocs-rs/src/events.rs
+++ b/demoinfocs-rs/src/events.rs
@@ -599,7 +599,7 @@ pub struct RoundImpactScoreData {
 }
 
 #[derive(Clone, Debug)]
-pub struct RoundBackupFilenames {
+pub struct RawRoundBackupFilenames {
     pub raw_message: Option<crate::proto::msg::cs_demo_parser_rs::CcsUsrMsgRoundBackupFilenames>,
 }
 

--- a/demoinfocs-rs/src/lib.rs
+++ b/demoinfocs-rs/src/lib.rs
@@ -8,6 +8,7 @@ pub mod game_state;
 pub mod gamerules;
 pub mod matchinfo;
 pub mod parser;
+pub mod commands;
 pub mod proto;
 pub mod sendtables;
 pub mod sendtables1;

--- a/demoinfocs-rs/tests/commands.rs
+++ b/demoinfocs-rs/tests/commands.rs
@@ -1,0 +1,24 @@
+use std::io::Cursor;
+use prost::Message;
+use demoinfocs_rs::{bitreader::BitReader, commands::CommandBuilder, proto::msgs2::{CnetMsgTick, NetMessages}};
+
+fn read_bytes<R: std::io::Read>(reader: &mut BitReader<R>, len: usize) -> Vec<u8> {
+    (0..len).map(|_| reader.read_int(8) as u8).collect()
+}
+
+#[test]
+fn encode_tick_message() {
+    let mut builder = CommandBuilder::new();
+    let msg = CnetMsgTick { tick: Some(5), ..Default::default() };
+    builder.push_net_message(NetMessages::NetTick, &msg).unwrap();
+    let packet = builder.into_packet();
+    let data = packet.data.unwrap();
+
+    let mut reader = BitReader::new_large(Cursor::new(&data[..]));
+    let msg_type = reader.read_ubit_int();
+    assert_eq!(msg_type, NetMessages::NetTick as u32);
+    let size = reader.read_varint32() as usize;
+    let bytes = read_bytes(&mut reader, size);
+    let decoded = CnetMsgTick::decode(&bytes[..]).unwrap();
+    assert_eq!(decoded.tick, Some(5));
+}


### PR DESCRIPTION
## Summary
- add `commands` module for building demo commands
- expose new module in `lib.rs`
- rename duplicate struct in `events.rs`
- test command generation in `tests/commands.rs`

## Testing
- `cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check`
- `cargo clippy --manifest-path demoinfocs-rs/Cargo.toml`
- `cargo test --manifest-path demoinfocs-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6868d3ab6a7883268b156a25758a3406