### PR TITLE
Improve protobuf build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Install protobuf dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libprotobuf-dev
+
       # - name: Format
       #   run: cargo fmt --manifest-path demoinfocs-rs/Cargo.toml -- --check
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Install the protobuf compiler before building. On Debian/Ubuntu systems:
 sudo apt-get install protobuf-compiler libprotobuf-dev
 ```
 
+The file `google/protobuf/descriptor.proto` is needed for code generation. It is
+usually provided by the `libprotobuf-dev` package. If you installed protobuf to
+a custom location, set the `PROTOC_INCLUDE` environment variable to the
+directory containing this file.
+
 If `PROTOC_INCLUDE` is set, the build script will use it to locate
 `google/protobuf/descriptor.proto`. When `prost-build` is built with its
 bundled `protoc`, this variable is provided automatically.

--- a/demoinfocs-proto/build.rs
+++ b/demoinfocs-proto/build.rs
@@ -74,6 +74,16 @@ pub use cs_demo_parser_rs::*;
             }
         }
     }
+    // Ensure descriptor.proto exists in one of the include directories
+    let descriptor_found = includes
+        .iter()
+        .map(|p| p.join("google/protobuf/descriptor.proto"))
+        .any(|p| p.exists());
+    if !descriptor_found {
+        return Err(
+            "google/protobuf/descriptor.proto not found. Install libprotobuf-dev or set PROTOC_INCLUDE".into(),
+        );
+    }
     config.compile_protos(&protos, &includes)?;
     // Older prost versions generate a file named `_.rs`. Rename it for
     // consistency so the module is always `cs_demo_parser_rs`.


### PR DESCRIPTION
## Summary
- check for descriptor.proto and fail with a helpful error
- clarify README about the descriptor file
- install protobuf packages in CI

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test` *(fails: encode_tick_message)*

------
https://chatgpt.com/codex/tasks/task_e_68698ded6d8883268bada13d2fb36c78