### PR TITLE
Add wasm build support and update documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rayon = "1.10"
 
 

--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -28,7 +28,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 ## Examples and Utilities
 - [x] **Voice capture example** – implemented using `Parser::register_net_message_handler`.
   Run `cargo run --example voice_capture -- -demo <demo> -out voice.raw` to dump the raw audio stream.
-- [ ] **WebAssembly bindings** – port the old WASM example and ensure the crate builds for `wasm32-unknown-unknown`.
+- [x] **WebAssembly bindings** – port the old WASM example and ensure the crate builds for `wasm32-unknown-unknown`.
 - [x] **Parallel processing** – reintroduce the parallel parsing utilities for batch processing multiple demos.
 - [ ] **Command helpers** – port the `s2_commands.go` helpers for crafting demo commands.
 

--- a/docs/examples/web-assembly/README.md
+++ b/docs/examples/web-assembly/README.md
@@ -1,6 +1,22 @@
 # WebAssembly (WASM)
 
-This example shows how to use the library with [WebAssembly](https://webassembly.org/).
+This example shows how to build the parser for [WebAssembly](https://webassembly.org/) and expose a
+simple API. The `parse_demo` function takes the raw demo bytes and returns a list
+of player names as a JavaScript value.
 
-Since the build process is somewhat different from the library itself, the example has it's own repository which you can find here:
-https://github.com/markus-wa/demoinfocs-wasm
+## Building
+
+```
+rustup target add wasm32-unknown-unknown
+cargo build --target wasm32-unknown-unknown --example web_assembly
+```
+
+After compilation run `wasm-bindgen` on the produced `.wasm` file to generate the
+JavaScript bindings:
+
+```
+wasm-bindgen --target web target/wasm32-unknown-unknown/debug/examples/web_assembly.wasm --out-dir out
+```
+
+The complete browser integration is shown in a dedicated repository:
+<https://github.com/markus-wa/demoinfocs-wasm>

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod net_encryption;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod parallel;
 mod steamid;
 

--- a/src/utils/parallel.rs
+++ b/src/utils/parallel.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use rayon::prelude::*;
 use std::fs::File;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary
- gate the parallel utilities so the crate builds on wasm32
- make `rayon` an optional dependency for non-wasm targets
- flesh out the WebAssembly example docs
- mark WebAssembly bindings as complete in the porting checklist

## Testing
- `cargo build --target wasm32-unknown-unknown --example web_assembly`
- `cargo test` *(fails: encode_tick_message)*
- `cargo fmt -- --check`
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_e_68698dd2338c8326922e16755377f83e