### PR TITLE
Implement player helper methods

### DIFF
--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -13,7 +13,7 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
 
 ## Game State and Entities
 - [x] **Complete entity tracking** – Source 1 entity tables are available and basic projectile ownership and dropped weapon tracking works for Source 2 demos.
-- [ ] **Full `Player` API** – port remaining helper methods (`IsInBombZone`, `IsDucking`, `IsScoped`, `IsSpottedBy`, etc.).
+- [x] **Full `Player` API** – port remaining helper methods (`IsInBombZone`, `IsDucking`, `IsScoped`, `IsSpottedBy`, etc.).
 
 - [ ] **Inferno and grenade helpers** – replicate convex hull calculations and trajectory tracking from `inferno.go` and `grenade.go`.
 - [ ] **Game rules and match info** – implement the structures and callbacks from `gamerules.go` and `matchinfo.go`.

--- a/src/common/player.rs
+++ b/src/common/player.rs
@@ -212,4 +212,43 @@ impl Player {
             })
             .unwrap_or(false)
     }
+    pub fn has_spotted(&self, other: &Player) -> bool {
+        other.is_spotted_by(self)
+    }
+
+    pub fn is_in_buy_zone(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_bInBuyZone"))
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn is_walking(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_bIsWalking"))
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn is_grabbing_hostage(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_bIsGrabbingHostage"))
+            .map(|v| v.bool_val())
+            .unwrap_or(false)
+    }
+
+    pub fn is_airborne(&self) -> bool {
+        self.entity
+            .as_ref()
+            .and_then(|e| e.property_value("m_hGroundEntity"))
+            .map(|v| v.int_val as u32 == constants::INVALID_ENTITY_HANDLE)
+            .unwrap_or(false)
+    }
+
+    pub fn is_blinded(&self) -> bool {
+        self.flash_duration > 0.0
+    }
 }

--- a/tests/player.rs
+++ b/tests/player.rs
@@ -91,3 +91,57 @@ fn gear_alt_property_names() {
     assert!(p.has_defuse_kit());
     assert!(p.has_helmet());
 }
+
+#[test]
+fn bomb_zone_duck_scoped() {
+    let ent = make_entity(vec![
+        ("m_bInBombZone", 1),
+        ("m_bDucking", 1),
+        ("m_bIsScoped", 0),
+    ]);
+    let p = Player {
+        entity: Some(ent),
+        ..Default::default()
+    };
+    assert!(p.is_in_bomb_zone());
+    assert!(p.is_ducking());
+    assert!(!p.is_scoped());
+}
+
+#[test]
+fn spotted_helpers() {
+    let target_ent = make_entity(vec![("m_bSpottedByMask.000", 2)]);
+    let spotter_ent = make_entity(vec![]);
+    let target = Player {
+        entity: Some(target_ent),
+        entity_id: 1,
+        ..Default::default()
+    };
+    let spotter = Player {
+        entity: Some(spotter_ent),
+        entity_id: 1,
+        ..Default::default()
+    };
+    assert!(target.is_spotted_by(&spotter));
+    assert!(spotter.has_spotted(&target));
+}
+
+#[test]
+fn extra_helpers() {
+    let ent = make_entity(vec![
+        ("m_bInBuyZone", 1),
+        ("m_bIsWalking", 1),
+        ("m_bIsGrabbingHostage", 0),
+        ("m_hGroundEntity", -1),
+    ]);
+    let p = Player {
+        entity: Some(ent),
+        flash_duration: 1.0,
+        ..Default::default()
+    };
+    assert!(p.is_in_buy_zone());
+    assert!(p.is_walking());
+    assert!(!p.is_grabbing_hostage());
+    assert!(p.is_airborne());
+    assert!(p.is_blinded());
+}


### PR DESCRIPTION
## Summary
- expand Player helpers with more methods
- add tests for the new helpers
- mark Player API porting work as complete in the porting status

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test` *(fails: test `encode_tick_message` in `tests/commands.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68698da7b7a883269db868690f61f002