### PR TITLE
Implement command builder helpers

### DIFF
--- a/docs/PORTING_STATUS.md
+++ b/docs/PORTING_STATUS.md
@@ -30,6 +30,6 @@ The legacy Go library under `pkg/` exposed a large API surface. The current `dem
   Run `cargo run --example voice_capture -- -demo <demo> -out voice.raw` to dump the raw audio stream.
 - [ ] **WebAssembly bindings** – port the old WASM example and ensure the crate builds for `wasm32-unknown-unknown`.
 - [x] **Parallel processing** – reintroduce the parallel parsing utilities for batch processing multiple demos.
-- [ ] **Command helpers** – port the `s2_commands.go` helpers for crafting demo commands.
+- [x] **Command helpers** – port the `s2_commands.go` helpers for crafting demo commands.
 
 This checklist is meant as guidance for achieving feature parity with the old Go library. As functionality is added, update this document to track remaining work.


### PR DESCRIPTION
## Summary
- port helper functions from `s2_commands.go`
- support appending raw net message bytes and returning encoded bytes
- test new helpers and fix existing test
- mark command helper task as complete

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68698dd990b0832691525d36a8bb8a5f