### PR TITLE
Fix CommandBuilder packet encoding

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,7 +29,6 @@ fn write_varint32<W: std::io::Write>(
     writer: &mut BitWriter<W, LittleEndian>,
     mut value: u32,
 ) -> std::io::Result<()> {
-    writer.byte_align();
     loop {
         let mut b = (value & 0x7f) as u8;
         value >>= 7;
@@ -66,7 +65,6 @@ impl CommandBuilder {
         write_ubit_int(&mut self.writer, ty as u32)?;
         let buf = msg.encode_to_vec();
         write_varint32(&mut self.writer, buf.len() as u32)?;
-        self.writer.byte_align();
         for b in buf {
             self.writer.write(8, b as u32)?;
         }


### PR DESCRIPTION
## Summary
- fix bit alignment in CommandBuilder so encoded packets match expectations

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68698e08b170832690031668ed70d81b