### PR TITLE
Fix tests and update docs

### DIFF
--- a/docs/examples/entities/README.md
+++ b/docs/examples/entities/README.md
@@ -4,11 +4,13 @@ This example shows how to use unhandled data of entities by registering entity-c
 
 ## Finding interesting server-classes & entity-properties
 
-You can use the build tag `debugdemoinfocs` and the set `debugServerClasses=YES` with ldflags to find interesting server-classes and their properties.
+Run the `entities` example to list all server-classes contained in a demo:
 
-Example: `cargo run --example myprogram -- -tags debugdemoinfocs -ldflags '-X github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs.debugServerClasses=YES' | grep ServerClass`
+```bash
+cargo run --example entities -- -demo /path/to/demo
+```
 
-This gives you a list of all server-classes from any demo that was parsed in `myprogram.rs`.
+This prints the ID and name of every server class encountered while parsing the demo.
 
 <details>
 <summary>Sample output</summary>
@@ -806,34 +808,11 @@ ServerClass: id=202 name=CWeaponAWP
 Registering the entity-creation handlers needs to be done after the DataTablesParsedEvent has been dispatched.
 Before that the server-classes won't be available in `Parser.ServerClasses()`.
 
-Property-update handlers that are registered in a entity-creation handler will be triggered with the initial value.
-
-This example prints the life-cycle of all AWPs during the game - i.e. who picked up whose AWP:
-
-```go
-p.RegisterEventHandler(func(events.DataTablesParsed) {
-	p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(ent st.Entity) {
-		ent.Property("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
-			x := p.GameState().Participants().FindByHandle(val.IntVal)
-			if x != nil {
-				var prev string
-				prevHandle := ent.Property("m_hPrevOwner").Value().IntVal
-				prevPlayer := p.GameState().Participants().FindByHandle(prevHandle)
-				if prevPlayer != nil {
-					if prevHandle != val.IntVal {
-						prev = prevPlayer.Name + "'s"
-					} else {
-						prev = "his dropped"
-					}
-				} else {
-					prev = "a brand new"
-				}
-				fmt.Printf("%s picked up %s AWP (#%d)\n", x.Name, prev, ent.ID())
-			}
-		})
-	})
-})
-```
+Property-update callbacks are not yet available in the Rust API.
+The current example simply lists every server class and prints basic
+information about newly created entities. See
+[`examples/entities.rs`](../../../examples/entities.rs) for the complete
+source code.
 
 ## Running the example
 

--- a/tests/player.rs
+++ b/tests/player.rs
@@ -132,7 +132,10 @@ fn extra_helpers() {
         ("m_bInBuyZone", 1),
         ("m_bIsWalking", 1),
         ("m_bIsGrabbingHostage", 0),
-        ("m_hGroundEntity", -1),
+        (
+            "m_hGroundEntity",
+            demoinfocs_rs::constants::INVALID_ENTITY_HANDLE as i32,
+        ),
     ]);
     let p = Player {
         entity: Some(ent),

--- a/tests/user_messages.rs
+++ b/tests/user_messages.rs
@@ -266,11 +266,14 @@ fn user_message_round_impact_score_data() {
 #[test]
 fn user_message_round_backup_filenames() {
     let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
-    let captured: Arc<Mutex<Option<CcsUsrMsgRoundBackupFilenames>>> = Arc::new(Mutex::new(None));
+    let captured: Arc<Mutex<Option<demoinfocs_rs::events::RoundBackupFilenames>>> =
+        Arc::new(Mutex::new(None));
     let cap = captured.clone();
-    parser.register_user_message_handler::<CcsUsrMsgRoundBackupFilenames, _>(move |m| {
-        *cap.lock().unwrap() = Some(m.clone());
-    });
+    parser.register_user_message_handler::<demoinfocs_rs::events::RoundBackupFilenames, _>(
+        move |m| {
+            *cap.lock().unwrap() = Some(m.clone());
+        },
+    );
 
     let msg = CcsUsrMsgRoundBackupFilenames {
         count: Some(3),
@@ -289,15 +292,15 @@ fn user_message_round_backup_filenames() {
     std::thread::sleep(std::time::Duration::from_millis(10));
 
     let got = captured.lock().unwrap().clone().unwrap();
-    assert_eq!(got.count.unwrap(), 3);
-    assert_eq!(got.index.unwrap(), 2);
-    assert_eq!(got.filename.unwrap(), "backup_02.dem");
-    assert_eq!(got.nicename.unwrap(), "backup round 2");
+    assert_eq!(got.count, 3);
+    assert_eq!(got.index, 2);
+    assert_eq!(got.filename, "backup_02.dem");
+    assert_eq!(got.nicename, "backup round 2");
 }
 
 #[test]
 fn user_message_vgui_menu() {
-    let parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
     let captured: Arc<Mutex<Option<demoinfocs_rs::events::VguiMenu>>> = Arc::new(Mutex::new(None));
     let cap = captured.clone();
     parser.register_user_message_handler::<demoinfocs_rs::events::VguiMenu, _>(move |m| {
@@ -338,7 +341,7 @@ fn user_message_vgui_menu() {
 
 #[test]
 fn user_message_show_menu() {
-    let parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
     let captured: Arc<Mutex<Option<demoinfocs_rs::events::ShowMenu>>> = Arc::new(Mutex::new(None));
     let cap = captured.clone();
     parser.register_user_message_handler::<demoinfocs_rs::events::ShowMenu, _>(move |m| {
@@ -368,7 +371,7 @@ fn user_message_show_menu() {
 
 #[test]
 fn user_message_bar_time() {
-    let parser = Parser::new(Cursor::new(Vec::<u8>::new()));
+    let mut parser = Parser::new(Cursor::new(Vec::<u8>::new()));
     let captured: Arc<Mutex<Option<demoinfocs_rs::events::BarTime>>> = Arc::new(Mutex::new(None));
     let cap = captured.clone();
     parser.register_user_message_handler::<demoinfocs_rs::events::BarTime, _>(move |m| {


### PR DESCRIPTION
## Summary
- ensure RoundBackupFilenames handler uses Rust event struct
- make some parsers mutable in tests
- use INVALID_ENTITY_HANDLE constant in player test
- drop outdated Go instructions in entities example

## Testing
- `cargo fmt -- --check`
- `cargo clippy -q`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68699583132483269ff197b6a0a2815e