### PR TITLE
Fix clippy errors and warnings

### DIFF
--- a/src/common/equipment.rs
+++ b/src/common/equipment.rs
@@ -88,12 +88,11 @@ pub enum EquipmentType {
     He = 506,
 }
 
-
 impl EquipmentType {
     pub fn class(self) -> EquipmentClass {
         let val = self as i32;
         let class_denominator = 100;
-        EquipmentClass::from((((val + class_denominator - 1) / class_denominator)))
+        EquipmentClass::from((val + class_denominator - 1) / class_denominator)
     }
 
     pub fn as_str(self) -> &'static str {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -311,18 +311,17 @@ impl GameState {
                 self.dropped_weapons.remove(&ev.entity.index);
                 self.grenade_projectiles.remove(&ev.entity.index);
                 self.infernos.remove(&ev.entity.index);
-            } else if ev.op.contains(EntityOp::CREATED) {
-                self.add_entity(ev.entity.clone());
-                self.update_special_entities(&ev.entity);
-            } else if ev.op.contains(EntityOp::UPDATED) {
+            } else if ev.op.contains(EntityOp::CREATED) || ev.op.contains(EntityOp::UPDATED) {
                 self.add_entity(ev.entity.clone());
                 self.update_special_entities(&ev.entity);
             }
-        } else if any.is::<crate::events::FrameDone>()
-            && let Some(fb) = self.flying_flashbangs.first()
-                && fb.exploded_frame > 0 && fb.exploded_frame < self.ingame_tick {
+        } else if any.is::<crate::events::FrameDone>() {
+            if let Some(fb) = self.flying_flashbangs.first() {
+                if fb.exploded_frame > 0 && fb.exploded_frame < self.ingame_tick {
                     self.flying_flashbangs.remove(0);
                 }
+            }
+        }
     }
 
     pub fn handle_net_message<M: 'static>(&mut self, msg: &M) {

--- a/src/parser/datatable.rs
+++ b/src/parser/datatable.rs
@@ -72,17 +72,17 @@ pub fn build_equipment_mapping(
             out.insert(name, EquipmentType::Knife);
             continue;
         }
-        if name.starts_with("CWeapon") {
-            let eq = map_equipment(&name[7..]);
+        if let Some(stripped) = name.strip_prefix("CWeapon") {
+            let eq = map_equipment(stripped);
             out.insert(name, eq);
             continue;
         }
         let dt = sc.data_table_name.as_str();
-        if dt.starts_with("DT_Weapon") {
-            let eq = map_equipment(&dt[9..]);
+        if let Some(stripped) = dt.strip_prefix("DT_Weapon") {
+            let eq = map_equipment(stripped);
             out.insert(name, eq);
-        } else if dt.starts_with("DT_") {
-            let eq = map_equipment(&dt[3..]);
+        } else if let Some(stripped) = dt.strip_prefix("DT_") {
+            let eq = map_equipment(stripped);
             if eq != EquipmentType::Unknown {
                 out.insert(name, eq);
             }

--- a/src/sendtables2/field_path.rs
+++ b/src/sendtables2/field_path.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use once_cell::sync::Lazy;
 
 use super::huffman::{Node, build_huffman_tree};

--- a/src/sendtables2/field_type.rs
+++ b/src/sendtables2/field_type.rs
@@ -14,13 +14,14 @@ impl FieldType {
             name = &name[..name.len() - 1];
         }
         let mut count = 0;
-        if let Some(idx) = name.rfind('[')
-            && name.ends_with(']') {
+        if let Some(idx) = name.rfind('[') {
+            if name.ends_with(']') {
                 if let Ok(n) = name[idx + 1..name.len() - 1].parse() {
                     count = n;
                 }
                 name = &name[..idx];
             }
+        }
         let generic_type = if let Some(start) = name.find('<') {
             if let Some(end) = name.rfind('>') {
                 let inner = &name[start + 1..end];

--- a/src/sendtables2/huffman.rs
+++ b/src/sendtables2/huffman.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #[derive(Clone)]
 pub enum Node {
     Leaf {

--- a/src/sendtables2/mod.rs
+++ b/src/sendtables2/mod.rs
@@ -178,10 +178,11 @@ impl Parser {
                     } else if let Some(ent) = self.entities.get(&index).cloned() {
                         events.push((ent, EntityOp::UPDATED));
                     }
-                } else if cmd & 0x02 != 0
-                    && let Some(ent) = self.entities.remove(&index) {
+                } else if cmd & 0x02 != 0 {
+                    if let Some(ent) = self.entities.remove(&index) {
                         events.push((ent, EntityOp::DELETED | EntityOp::LEFT));
                     }
+                }
                 updates -= 1;
             }
         }

--- a/src/sendtables2/reader.rs
+++ b/src/sendtables2/reader.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 pub struct Reader<'a> {
     buf: &'a [u8],
     pos: usize,

--- a/src/stringtables.rs
+++ b/src/stringtables.rs
@@ -48,8 +48,8 @@ impl StringTables {
         &mut self,
         msg: &msg::CsvcMsgUpdateStringTable,
     ) -> Option<StringTable> {
-        if let Some(id) = msg.table_id
-            && let Some(table) = self.tables.get_mut(&id) {
+        if let Some(id) = msg.table_id {
+            if let Some(table) = self.tables.get_mut(&id) {
                 if let Some(data) = &msg.string_data {
                     let entry = StringTableEntry {
                         value: String::from_utf8_lossy(data).into_owned(),
@@ -60,6 +60,7 @@ impl StringTables {
                 }
                 return Some(table.clone());
             }
+        }
         None
     }
 
@@ -106,10 +107,11 @@ impl StringTables {
             }
             let (msg_buf, rest) = slice.split_at(size);
             slice = rest;
-            if let Ok(t) = msg::SvcMessages::try_from(msg_id as i32)
-                && let Some(tbl) = self.parse_svc_message(t, msg_buf) {
+            if let Ok(t) = msg::SvcMessages::try_from(msg_id as i32) {
+                if let Some(tbl) = self.parse_svc_message(t, msg_buf) {
                     updates.push(tbl);
                 }
+            }
         }
         updates
     }


### PR DESCRIPTION
## Summary
- remove unstable let-chains from parser and helpers
- fix excessive parentheses in equipment enum
- simplify entity event handling
- replace manual prefix stripping in datatable parser
- avoid `Result<(), ()>` in parser close method
- add dead code suppression for unused sendtables2 utilities
- create type alias for dispatcher callbacks

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68699af50590832688c00e26a0e2bbdf