### PR TITLE
Improve demo header error handling

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -19,6 +19,8 @@ pub enum ParserError {
     UnexpectedEndOfDemo,
     /// The input does not look like a valid demo file.
     InvalidFileType,
+    /// The file appears to be a Git LFS pointer rather than a demo.
+    GitLfsPointer,
 }
 
 /// Information parsed from a demo's header.
@@ -326,6 +328,7 @@ impl<R: Read> Parser<R> {
         header.filestamp = self.bit_reader.read_c_string(8);
         match header.filestamp.as_str() {
             | "HL2DEMO" | "PBDEMS2" => {},
+            | "version" | "version " => return Err(ParserError::GitLfsPointer),
             | _ => return Err(ParserError::InvalidFileType),
         }
 

--- a/tests/demo_parsing.rs
+++ b/tests/demo_parsing.rs
@@ -39,6 +39,14 @@ fn invalid_file_type() {
 }
 
 #[test]
+fn git_lfs_pointer() {
+    let data = b"version https://git-lfs.github.com/spec/v1\n".to_vec();
+    let mut parser = Parser::new(Cursor::new(data));
+    let err = parser.parse_header().expect_err("expected error");
+    matches!(err, ParserError::GitLfsPointer);
+}
+
+#[test]
 fn example_print_events_runs() {
     let mut parser = MockParser::new();
     let called = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary
- detect Git LFS pointer files in header parsing
- expose new `ParserError::GitLfsPointer`
- test Git LFS pointer detection

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ab43eb5848326a7abdff5bc2e06c1