### PR TITLE
Fix signon frame handling

### DIFF
--- a/src/bitreader.rs
+++ b/src/bitreader.rs
@@ -26,6 +26,18 @@ impl<R: Read> BitReader<R> {
         Self::with_capacity(reader, LARGE_BUFFER)
     }
 
+    /// Skips the specified number of bits.
+    pub fn skip_bits(&mut self, bits: u32) {
+        let bytes = bits / 8;
+        let rem = bits % 8;
+        for _ in 0..bytes {
+            self.read_int(8);
+        }
+        for _ in 0..rem {
+            self.read_bit();
+        }
+    }
+
     pub fn read_int(&mut self, bits: u32) -> u32 {
         self.inner.read(bits).unwrap()
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -120,6 +120,7 @@ pub struct Parser<R: Read> {
     game_events: crate::game_events::GameEventHandler,
     header: Option<DemoHeader>,
     config: ParserConfig,
+    reading_signon: bool,
 }
 
 impl<R: Read> Parser<R> {
@@ -146,6 +147,7 @@ impl<R: Read> Parser<R> {
             game_events: crate::game_events::GameEventHandler::new(),
             header: None,
             config,
+            reading_signon: false,
         }
     }
 
@@ -343,6 +345,7 @@ impl<R: Read> Parser<R> {
         header.playback_frames = self.bit_reader.read_signed_int(32);
         header.signon_length = self.bit_reader.read_signed_int(32);
 
+        self.reading_signon = header.filestamp == "HL2DEMO" && header.signon_length > 0;
         self.header = Some(header.clone());
         Ok(header)
     }
@@ -386,20 +389,39 @@ impl<R: Read> Parser<R> {
         self.bit_reader.read_int(8); // player slot
 
         match cmd {
+            // Signon or packet
+            | 0 | 1 => {
+                const SKIP_BITS: u32 = (152 + 4 + 4) * 8;
+                for _ in 0..SKIP_BITS {
+                    self.bit_reader.read_bit();
+                }
+                let size = self.bit_reader.read_signed_int(32) as u32;
+                for _ in 0..size {
+                    self.bit_reader.read_int(8);
+                }
+                Ok(true)
+            },
             // SyncTick
-            3 => Ok(true),
-            // Stop
-            0 => Ok(false),
+            | 2 => Ok(true),
             // Console command
-            9 => {
+            | 3 => {
                 let len = self.bit_reader.read_signed_int(32) as u32;
                 for _ in 0..len {
                     self.bit_reader.read_int(8);
                 }
                 Ok(true)
-            }
+            },
+            // User command
+            | 4 => {
+                self.bit_reader.read_int(32); // command number
+                let len = self.bit_reader.read_signed_int(32) as u32;
+                for _ in 0..len {
+                    self.bit_reader.read_int(8);
+                }
+                Ok(true)
+            },
             // Send tables
-            4 => {
+            | 5 => {
                 let len = self.bit_reader.read_signed_int(32) as usize;
                 let mut data = Vec::with_capacity(len);
                 for _ in 0..len {
@@ -416,9 +438,9 @@ impl<R: Read> Parser<R> {
                 }
 
                 Ok(true)
-            }
+            },
             // String tables
-            6 => {
+            | 8 => {
                 let len = self.bit_reader.read_signed_int(32) as usize;
                 let mut data = Vec::with_capacity(len);
                 for _ in 0..len {
@@ -426,37 +448,33 @@ impl<R: Read> Parser<R> {
                 }
                 self.parse_stringtable_packet(&data);
                 Ok(true)
-            }
-            // User command
-            12 => {
-                self.bit_reader.read_int(32); // command number
+            },
+            // Custom data
+            | 7 => {
                 let len = self.bit_reader.read_signed_int(32) as u32;
                 for _ in 0..len {
                     self.bit_reader.read_int(8);
                 }
                 Ok(true)
-            }
-            // Packets (normal, signon or full)
-            7 | 8 | 13 => {
-                const SKIP_BITS: u32 = (152 + 4 + 4) * 8;
-                for _ in 0..SKIP_BITS {
-                    self.bit_reader.read_bit();
+            },
+            // Stop
+            | 6 => {
+                if self.reading_signon {
+                    self.reading_signon = false;
+                    Ok(true)
+                } else {
+                    Ok(false)
                 }
-                let size = self.bit_reader.read_signed_int(32) as u32;
-                for _ in 0..size {
-                    self.bit_reader.read_int(8);
-                }
-                Ok(true)
-            }
+            },
             // Unhandled but length-prefixed commands
-            1 | 2 | 5 | 10 | 11 | 14 | 15 | 16 | 17 | 18 => {
+            | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 => {
                 let len = self.bit_reader.read_signed_int(32) as u32;
                 for _ in 0..len {
                     self.bit_reader.read_int(8);
                 }
                 Ok(true)
-            }
-            _ => Ok(true),
+            },
+            | _ => Ok(true),
         }
         .map(|res| {
             if res {


### PR DESCRIPTION
## Summary
- correct Source 1 demo command numbers
- treat signon and packet commands as packets
- add helper to skip bits in `BitReader`

## Testing
- `cargo clippy -- -A warnings`
- `cargo test --quiet`
- `cargo run --example debug_dump full-demo/2015-08-23-ESLOneCologne2015-fnatic-vs-virtuspro-mirage.dem | head -n 20` *(fails with UnexpectedEndOfDemo)*

------
https://chatgpt.com/codex/tasks/task_e_686b0d0c9f448326b109c876e53a2296