### PR TITLE
Address many clippy warnings

### DIFF
--- a/demoinfocs-proto/build.rs
+++ b/demoinfocs-proto/build.rs
@@ -36,12 +36,19 @@ fn ensure_descriptor_proto(vendor_dir: &Path) -> Result<(), Box<dyn std::error::
     println!("cargo:warning=Downloading descriptor.proto from {}...", url);
     let resp = reqwest::blocking::get(url)?;
     if !resp.status().is_success() {
-        return Err(format!("Failed to download descriptor.proto: HTTP {}", resp.status()).into());
+        return Err(format!(
+            "Failed to download descriptor.proto: HTTP {}",
+            resp.status()
+        )
+        .into());
     }
     std::fs::create_dir_all(descriptor_path.parent().unwrap())?;
     let mut file = std::fs::File::create(&descriptor_path)?;
     file.write_all(&resp.bytes()?)?;
-    println!("cargo:warning=Downloaded descriptor.proto to {}", descriptor_path.display());
+    println!(
+        "cargo:warning=Downloaded descriptor.proto to {}",
+        descriptor_path.display()
+    );
     Ok(())
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -89,3 +89,9 @@ impl CommandBuilder {
         self.writer.into_writer()
     }
 }
+
+impl Default for CommandBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/common/equipment.rs
+++ b/src/common/equipment.rs
@@ -1,8 +1,9 @@
 use crate::sendtables::entity::{Entity, Vector};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum EquipmentClass {
+    #[default]
     Unknown = 0,
     Pistols = 1,
     Smg = 2,
@@ -12,15 +13,10 @@ pub enum EquipmentClass {
     Grenade = 6,
 }
 
-impl Default for EquipmentClass {
-    fn default() -> Self {
-        EquipmentClass::Unknown
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum EquipmentType {
+    #[default]
     Unknown = 0,
     // Pistols
     P2000 = 1,
@@ -91,17 +87,11 @@ pub enum EquipmentType {
     He = 506,
 }
 
-impl Default for EquipmentType {
-    fn default() -> Self {
-        EquipmentType::Unknown
-    }
-}
-
 impl EquipmentType {
     pub fn class(self) -> EquipmentClass {
         let val = self as i32;
         let class_denominator = 100;
-        EquipmentClass::from(((val + class_denominator - 1) / class_denominator) as i32)
+        EquipmentClass::from((val + class_denominator - 1) / class_denominator)
     }
 
     pub fn as_str(self) -> &'static str {

--- a/src/common/player.rs
+++ b/src/common/player.rs
@@ -3,36 +3,26 @@ use crate::constants;
 use crate::sendtables::entity::{Entity, Vector};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(u8)]
 pub enum Team {
+    #[default]
     Unassigned = 0,
     Spectators = 1,
     Terrorists = 2,
     CounterTerrorists = 3,
 }
 
-impl Default for Team {
-    fn default() -> Self {
-        Team::Unassigned
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(i32)]
 pub enum Color {
+    #[default]
     Grey = -1,
     Yellow = 0,
     Purple = 1,
     Green = 2,
     Blue = 3,
     Orange = 4,
-}
-
-impl Default for Color {
-    fn default() -> Self {
-        Color::Grey
-    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -61,7 +51,7 @@ impl Player {
     pub fn position(&self) -> Vector {
         self.entity
             .as_ref()
-            .and_then(|_| Some(self.last_alive_position.clone()))
+            .map(|_| self.last_alive_position.clone())
             .unwrap_or_else(|| self.last_alive_position.clone())
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -56,7 +56,7 @@ impl EventDispatcher {
         {
             thread::spawn(move || {
                 for event in rx.iter() {
-                    let t = (&*event).type_id();
+                    let t = event.as_ref().type_id();
                     let handlers = {
                         let map = this.handlers.read().unwrap();
                         map.get(&t).cloned()

--- a/src/events.rs
+++ b/src/events.rs
@@ -107,21 +107,11 @@ pub struct POVRecordingPlayerDetected {
 #[derive(Clone, Debug)]
 pub struct MatchStart;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RoundStart {
     pub time_limit: i32,
     pub frag_limit: i32,
     pub objective: String,
-}
-
-impl Default for RoundStart {
-    fn default() -> Self {
-        Self {
-            time_limit: 0,
-            frag_limit: 0,
-            objective: String::new(),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -240,25 +230,13 @@ pub struct WeaponReload {
     pub player: Option<Player>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GrenadeEvent {
     pub grenade_type: EquipmentType,
     pub grenade: Option<Equipment>,
     pub position: Vector,
     pub thrower: Option<Player>,
     pub grenade_entity_id: i32,
-}
-
-impl Default for GrenadeEvent {
-    fn default() -> Self {
-        Self {
-            grenade_type: 0,
-            grenade: None,
-            position: Vector::default(),
-            thrower: None,
-            grenade_entity_id: 0,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -311,10 +311,7 @@ impl GameState {
                 self.dropped_weapons.remove(&ev.entity.index);
                 self.grenade_projectiles.remove(&ev.entity.index);
                 self.infernos.remove(&ev.entity.index);
-            } else if ev.op.contains(EntityOp::CREATED) {
-                self.add_entity(ev.entity.clone());
-                self.update_special_entities(&ev.entity);
-            } else if ev.op.contains(EntityOp::UPDATED) {
+            } else if ev.op.contains(EntityOp::CREATED) || ev.op.contains(EntityOp::UPDATED) {
                 self.add_entity(ev.entity.clone());
                 self.update_special_entities(&ev.entity);
             }

--- a/src/gamerules.rs
+++ b/src/gamerules.rs
@@ -1,6 +1,7 @@
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 #[repr(u8)]
 pub enum GamePhase {
+    #[default]
     Init = 0,
     Pregame = 1,
     StartGamePhase = 2,
@@ -9,12 +10,6 @@ pub enum GamePhase {
     GameEnded = 5,
     StaleMate = 6,
     GameOver = 7,
-}
-
-impl Default for GamePhase {
-    fn default() -> Self {
-        GamePhase::Init
-    }
 }
 
 impl std::fmt::Display for GamePhase {

--- a/src/parser/datatable.rs
+++ b/src/parser/datatable.rs
@@ -73,7 +73,7 @@ pub fn build_equipment_mapping(
             continue;
         }
         if name.starts_with("CWeapon") {
-            let eq = map_equipment(&name[7..]);
+            let eq = map_equipment(name.trim_start_matches("CWeapon"));
             out.insert(name, eq);
             continue;
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -693,29 +693,29 @@ impl<R: Read> Parser<R> {
         if let Ok(kind) = proto_msg::SvcMessages::try_from(msg_type as i32) {
             match kind {
                 | proto_msg::SvcMessages::SvcServerInfo => {
-                    if let Ok(msg) = proto_msg::CsvcMsgServerInfo::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgServerInfo::decode(buf) {
                         self.s2_tables.on_server_info(&msg);
                         self.game_state.match_info.map = msg.map_name.clone();
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcSendTable => {
-                    if let Ok(msg) = proto_msg::CsvcMsgSendTable::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgSendTable::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcClassInfo => {
-                    if let Ok(msg) = proto_msg::CsvcMsgClassInfo::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgClassInfo::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcSetPause => {
-                    if let Ok(msg) = proto_msg::CsvcMsgSetPause::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgSetPause::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcCreateStringTable => {
-                    if let Ok(msg) = proto_msg::CsvcMsgCreateStringTable::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgCreateStringTable::decode(buf) {
                         if let Some(t) = self.string_tables.on_create_string_table(&msg) {
                             self.dispatch_event(crate::events::StringTableCreated {
                                 table_name: t.name.clone(),
@@ -726,7 +726,7 @@ impl<R: Read> Parser<R> {
                     }
                 },
                 | proto_msg::SvcMessages::SvcUpdateStringTable => {
-                    if let Ok(msg) = proto_msg::CsvcMsgUpdateStringTable::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgUpdateStringTable::decode(buf) {
                         if let Some(t) = self.string_tables.on_update_string_table(&msg) {
                             self.dispatch_event(StringTableUpdated { table: t });
                         }
@@ -734,69 +734,69 @@ impl<R: Read> Parser<R> {
                     }
                 },
                 | proto_msg::SvcMessages::SvcVoiceInit => {
-                    if let Ok(msg) = proto_msg::CsvcMsgVoiceInit::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgVoiceInit::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcVoiceData => {
-                    if let Ok(msg) = proto_msg::CsvcMsgVoiceData::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgVoiceData::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcPrint => {
-                    if let Ok(msg) = proto_msg::CsvcMsgPrint::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgPrint::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcSounds => {
-                    if let Ok(msg) = proto_msg::CsvcMsgSounds::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgSounds::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcSetView => {
-                    if let Ok(msg) = proto_msg::CsvcMsgSetView::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgSetView::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcFixAngle => {
-                    if let Ok(msg) = proto_msg::CsvcMsgFixAngle::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgFixAngle::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcCrosshairAngle => {
-                    if let Ok(msg) = proto_msg::CsvcMsgCrosshairAngle::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgCrosshairAngle::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcBspDecal => {
-                    if let Ok(msg) = proto_msg::CsvcMsgBspDecal::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgBspDecal::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcSplitScreen => {
-                    if let Ok(msg) = proto_msg::CsvcMsgSplitScreen::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgSplitScreen::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcUserMessage => {
-                    if let Ok(msg) = proto_msg::CsvcMsgUserMessage::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgUserMessage::decode(buf) {
                         self.handle_user_message(&msg);
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcEntityMessage => {
-                    if let Ok(msg) = proto_msg::CsvcMsgEntityMsg::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgEntityMsg::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcGameEvent => {
-                    if let Ok(msg) = proto_msg::CsvcMsgGameEvent::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgGameEvent::decode(buf) {
                         self.on_game_event(&msg);
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcPacketEntities => {
-                    if let Ok(msg) = proto_msg::CsvcMsgPacketEntities::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgPacketEntities::decode(buf) {
                         for (ent, op) in self.s2_tables.parse_packet_entities(&msg) {
                             let ev = EntityEvent {
                                 entity: ent.clone(),
@@ -811,53 +811,53 @@ impl<R: Read> Parser<R> {
                     }
                 },
                 | proto_msg::SvcMessages::SvcTempEntities => {
-                    if let Ok(msg) = proto_msg::CsvcMsgTempEntities::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgTempEntities::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcPrefetch => {
-                    if let Ok(msg) = proto_msg::CsvcMsgPrefetch::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgPrefetch::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcMenu => {
-                    if let Ok(msg) = proto_msg::CsvcMsgMenu::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgMenu::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcGameEventList => {
-                    if let Ok(msg) = proto_msg::CsvcMsgGameEventList::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgGameEventList::decode(buf) {
                         self.on_game_event_list(&msg);
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcGetCvarValue => {
-                    if let Ok(msg) = proto_msg::CsvcMsgGetCvarValue::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgGetCvarValue::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcPaintmapData => {
-                    if let Ok(msg) = proto_msg::CsvcMsgPaintmapData::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgPaintmapData::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcCmdKeyValues => {
-                    if let Ok(msg) = proto_msg::CsvcMsgCmdKeyValues::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgCmdKeyValues::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcEncryptedData => {
-                    if let Ok(msg) = proto_msg::CsvcMsgEncryptedData::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgEncryptedData::decode(buf) {
                         self.handle_encrypted_data(&msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcHltvReplay => {
-                    if let Ok(msg) = proto_msg::CsvcMsgHltvReplay::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgHltvReplay::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::SvcMessages::SvcBroadcastCommand => {
-                    if let Ok(msg) = proto_msg::CsvcMsgBroadcastCommand::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CsvcMsgBroadcastCommand::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
@@ -865,37 +865,37 @@ impl<R: Read> Parser<R> {
         } else if let Ok(net) = proto_msg::NetMessages::try_from(msg_type as i32) {
             match net {
                 | proto_msg::NetMessages::NetNop => {
-                    if let Ok(msg) = proto_msg::CnetMsgNop::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgNop::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetDisconnect => {
-                    if let Ok(msg) = proto_msg::CnetMsgDisconnect::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgDisconnect::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetFile => {
-                    if let Ok(msg) = proto_msg::CnetMsgFile::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgFile::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetSplitScreenUser => {
-                    if let Ok(msg) = proto_msg::CnetMsgSplitScreenUser::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgSplitScreenUser::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetTick => {
-                    if let Ok(msg) = proto_msg::CnetMsgTick::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgTick::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetStringCmd => {
-                    if let Ok(msg) = proto_msg::CnetMsgStringCmd::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgStringCmd::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetSetConVar => {
-                    if let Ok(msg) = proto_msg::CnetMsgSetConVar::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgSetConVar::decode(buf) {
                         if let Some(ref cvars) = msg.convars {
                             let mut map = HashMap::new();
                             for cv in &cvars.cvars {
@@ -915,12 +915,12 @@ impl<R: Read> Parser<R> {
                     }
                 },
                 | proto_msg::NetMessages::NetSignonState => {
-                    if let Ok(msg) = proto_msg::CnetMsgSignonState::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgSignonState::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },
                 | proto_msg::NetMessages::NetPlayerAvatarData => {
-                    if let Ok(msg) = proto_msg::CnetMsgPlayerAvatarData::decode(&buf[..]) {
+                    if let Ok(msg) = proto_msg::CnetMsgPlayerAvatarData::decode(buf) {
                         self.dispatch_net_message(msg);
                     }
                 },

--- a/src/sendtables/propdecoder.rs
+++ b/src/sendtables/propdecoder.rs
@@ -115,12 +115,12 @@ impl PropertyDecoder {
             if prop.flags.contains(SendPropertyFlags::UNSIGNED) {
                 return reader.read_varint32() as i32;
             }
-            return reader.read_signed_varint32() as i32;
+            return reader.read_signed_varint32();
         }
         if prop.flags.contains(SendPropertyFlags::UNSIGNED) {
             reader.read_int(prop.number_of_bits) as i32
         } else {
-            reader.read_signed_int(prop.number_of_bits) as i32
+            reader.read_signed_int(prop.number_of_bits)
         }
     }
 

--- a/src/sendtables/serverclass.rs
+++ b/src/sendtables/serverclass.rs
@@ -96,7 +96,7 @@ impl ServerClass {
         }
 
         // Only apply updates if baseline data contains any bits
-        if self.instance_baseline.len() > 0 || self.preprocessed_baseline.len() > 0 {
+        if !self.instance_baseline.is_empty() || !self.preprocessed_baseline.is_empty() {
             ent.apply_update(reader);
         }
         ent

--- a/src/sendtables2/field_path.rs
+++ b/src/sendtables2/field_path.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use once_cell::sync::Lazy;
 
 use super::huffman::{Node, build_huffman_tree};
@@ -34,6 +36,12 @@ impl FieldPath {
             last: self.last,
             done: self.done,
         }
+    }
+}
+
+impl Default for FieldPath {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/sendtables2/huffman.rs
+++ b/src/sendtables2/huffman.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 #[derive(Clone)]
 pub enum Node {
     Leaf {

--- a/src/sendtables2/mod.rs
+++ b/src/sendtables2/mod.rs
@@ -175,10 +175,8 @@ impl Parser {
                             self.entities.insert(index, ent.clone());
                             events.push((ent, EntityOp::CREATED | EntityOp::ENTERED));
                         }
-                    } else {
-                        if let Some(ent) = self.entities.get(&index).cloned() {
-                            events.push((ent, EntityOp::UPDATED));
-                        }
+                    } else if let Some(ent) = self.entities.get(&index).cloned() {
+                        events.push((ent, EntityOp::UPDATED));
                     }
                 } else if cmd & 0x02 != 0 {
                     if let Some(ent) = self.entities.remove(&index) {

--- a/src/sendtables2/reader.rs
+++ b/src/sendtables2/reader.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub struct Reader<'a> {
     buf: &'a [u8],
     pos: usize,


### PR DESCRIPTION
## Summary
- fix formatting in proto build script
- implement `Default` for builder and enums
- drop redundant slicing in parser
- allow unused code in sendtables2 module
- make minor clippy cleanups (prefix stripping, if collapse, etc.)

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b4f8606748326936a544702c9831f