### PR TITLE
Add demo lump parser

### DIFF
--- a/src/parser/lumps.rs
+++ b/src/parser/lumps.rs
@@ -1,0 +1,41 @@
+use crate::bitreader::BitReader;
+
+/// Information about lump data found in a demo.
+#[derive(Debug, Default)]
+pub struct LumpInfo {
+    /// The total size of all lump data following the lump table.
+    pub data_size: u64,
+}
+
+impl LumpInfo {
+    /// Parses the lump table that follows the demo header and returns the
+    /// combined size of all lumps. The reader is left positioned at the first
+    /// byte after the table.
+    pub fn parse<R: std::io::Read>(reader: &mut BitReader<R>) -> Self {
+        // Magic identifying a lump table.
+        const LUMP_MAGIC: u32 = 0xba80b001;
+
+        let magic = reader.read_int(32);
+        debug_assert_eq!(magic, LUMP_MAGIC, "unexpected lump table magic");
+
+        let count = reader.read_int(32);
+        // Skip two unknown fields
+        reader.read_int(32);
+        reader.read_int(32);
+        let mut max_end = 0u64;
+        for _ in 0..count {
+            let mut vals = [0u32; 8];
+            for v in &mut vals {
+                *v = reader.read_int(32);
+            }
+            for pair in (0..8).step_by(2) {
+                let end = vals[pair] as u64 + vals[pair + 1] as u64;
+                if end > max_end {
+                    max_end = end;
+                }
+            }
+        }
+
+        Self { data_size: max_end }
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,7 @@ use crate::sendtables2;
 use crate::stringtables;
 
 pub mod datatable;
+pub mod lumps;
 
 use prost::Message;
 use std::collections::HashMap;
@@ -122,6 +123,7 @@ pub struct Parser<R: Read> {
     config: ParserConfig,
     reading_signon: bool,
     signon_skipped: bool,
+    lump_size: u64,
 }
 
 impl<R: Read> Parser<R> {
@@ -150,6 +152,7 @@ impl<R: Read> Parser<R> {
             config,
             reading_signon: false,
             signon_skipped: false,
+            lump_size: 0,
         }
     }
 
@@ -346,6 +349,7 @@ impl<R: Read> Parser<R> {
         header.playback_ticks = self.bit_reader.read_signed_int(32);
         header.playback_frames = self.bit_reader.read_signed_int(32);
         header.signon_length = self.bit_reader.read_signed_int(32);
+        self.lump_size = crate::parser::lumps::LumpInfo::parse(&mut self.bit_reader).data_size;
 
         self.reading_signon = header.filestamp == "HL2DEMO" && header.signon_length > 0;
         self.header = Some(header.clone());
@@ -363,6 +367,9 @@ impl<R: Read> Parser<R> {
             if let Some(h) = &self.header {
                 if h.filestamp == "HL2DEMO" && h.signon_length > 0 {
                     for _ in 0..h.signon_length {
+                        self.bit_reader.read_int(8);
+                    }
+                    for _ in 0..self.lump_size {
                         self.bit_reader.read_int(8);
                     }
                 }


### PR DESCRIPTION
## Summary
- parse the lump table right after the header and record its data size
- skip lump data after sign-on bytes when parsing frames

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686b57003b1c832692339cd877df9161