### PR TITLE
Fix HL2DEMO header parsing

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -355,13 +355,30 @@ impl<R: Read> Parser<R> {
         header.playback_frames = self.bit_reader.read_signed_int(32);
         header.signon_length = self.bit_reader.read_signed_int(32);
 
-        if header.filestamp == "PBDEMS2" {
+        // Some demos include a lump table directly after the header. For
+        // Source 2 demos the lumps contain additional data that needs to be
+        // skipped before parsing frames. Source 1 demos may contain an empty or
+        // garbage lump table which should simply be skipped if present.
+        if self.bit_reader.peek_u32() == Some(crate::parser::lumps::LUMP_MAGIC) {
             let lump_info = crate::parser::lumps::LumpInfo::parse(&mut self.bit_reader);
-            self.lump_size = lump_info.data_size;
+            if header.filestamp == "PBDEMS2" {
+                self.lump_size = lump_info.data_size;
+            } else {
+                // Source 1 demos don't actually use lump data but still embed
+                // the table. Only the table itself needs to be skipped.
+                self.lump_size = 0;
+            }
         } else {
             self.lump_size = 0;
         }
-        self.reading_signon = header.filestamp == "HL2DEMO" && header.signon_length > 0;
+        if header.filestamp == "HL2DEMO" && header.signon_length > 0 {
+            for _ in 0..header.signon_length {
+                self.bit_reader.read_int(8);
+            }
+            self.reading_signon = false;
+        } else {
+            self.reading_signon = false;
+        }
         self.header = Some(header.clone());
 
         Ok(header)


### PR DESCRIPTION
## Summary
- parse and skip Source 1 lump table
- ignore signon data in HL2DEMO demos

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686db1fc29288326a81764e635c7d62b