### PR TITLE
Fix signon parsing and update debugging checklist

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -7,8 +7,11 @@ The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when read
 - [x] Validate that `BitReader` correctly handles EOF by inspecting `bitreader.rs` around `read_int` and verifying return values instead of unwrapping.
   - Added `catch_unwind` around header parsing so EOF now returns `UnexpectedEndOfDemo` instead of panicking.
 - [x] Investigate whether the demo file is truncated or corrupted by checking its size against the header values (playback frames, signon length, lump table sizes).
-  - The demo files in `demos/` are only ~130 bytes and start with the text "version". They are Git LFS pointer files, so the real demos were not downloaded. Run `git lfs pull` to fetch them before continuing.
+- The demo files in `demos/` are only ~130 bytes and start with the text "version". They are Git LFS pointer files, so the real demos were not downloaded. Run `git lfs pull` to fetch them before continuing.
+  - `git lfs pull` fails because no remote is configured. Need to copy real demo files manually for future runs.
 - [ ] Examine the lump table parsing in `debug_dump.rs` and compare with the official Valve demo specification to ensure offsets are computed correctly.
+- [x] Remove premature skipping of `signon_length` bytes in `Parser::parse_header` and set `reading_signon` accordingly.
+  - Header parsing no longer consumes signon data, preventing misaligned frame reads.
 - [ ] Add logging around `Parser::parse_next_frame` to identify which frame causes the EOF and what command was expected.
 - [ ] Compare the behaviour with other demo files known to work, to determine if the issue is data specific or systemic.
 - [ ] Consider validating the data after each read in `BitReader` to detect misaligned reads earlier.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -373,10 +373,7 @@ impl<R: Read> Parser<R> {
                 self.lump_size = 0;
             }
             if header.filestamp == "HL2DEMO" && header.signon_length > 0 {
-                for _ in 0..header.signon_length {
-                    self.bit_reader.read_int(8);
-                }
-                self.reading_signon = false;
+                self.reading_signon = true;
             } else {
                 self.reading_signon = false;
             }


### PR DESCRIPTION
## Summary
- don't consume signon bytes when reading the demo header
- mark `reading_signon` so Source 1 demos parse signon frames correctly
- note missing git LFS remote and record fix in debugging checklist

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686dcac33ad88326b63537e62d8f2252