### PR TITLE
Fix debug_dump lumps parsing

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -1,5 +1,20 @@
 # Debugging Steps for Unexpected EOF Panic
 
+**Latest panic stack trace**
+
+```
+thread 'main' panicked at src/parser/lumps.rs:21:9: assertion `left == right` failed: unexpected lump table magic
+  left: 10
+  right: 3128995841
+stack backtrace:
+   0: __rustc::rust_begin_unwind
+   1: core::panicking::panic_fmt
+   2: core::panicking::assert_failed_inner
+   3: core::panicking::assert_failed
+   4: cs_demo_parser::parser::lumps::LumpInfo::parse
+   5: debug_dump::main
+```
+
 The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when reading the demo file. The following checklist outlines investigation steps to resolve the issue.
 
 - [x] Re-run `cargo run --example debug_dump` with `RUST_BACKTRACE=1` to capture a full stack trace of the panic.
@@ -16,6 +31,8 @@ The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when read
     the correct format and only parse lumps for PBDEMS2 demos.
 - [x] Remove premature skipping of `signon_length` bytes in `Parser::parse_header` and set `reading_signon` accordingly.
   - Header parsing no longer consumes signon data, preventing misaligned frame reads.
+- [x] Skip lump parsing in `debug_dump` for HL2DEMO demos to avoid panicking on unexpected magic.
+  - Lumps are only present in PBDEMS2 demos. Source 1 demos should ignore the table entirely.
 - [ ] Add logging around `Parser::parse_next_frame` to identify which frame causes the EOF and what command was expected.
 - [ ] Compare the behaviour with other demo files known to work, to determine if the issue is data specific or systemic.
 - [ ] Consider validating the data after each read in `BitReader` to detect misaligned reads earlier.

--- a/examples/debug_dump.rs
+++ b/examples/debug_dump.rs
@@ -112,13 +112,22 @@ fn main() {
     println!("  Playback frames: {}", playback_frames);
 
     // Parse lump table for extra insight
-    let mut lump_file = File::open(&path).expect("Failed to reopen for lumps");
-    lump_file.seek(SeekFrom::Start(1072)).expect("seek lumps");
-    let mut lump_reader = cs_demo_parser::bitreader::BitReader::new_small(lump_file);
-    let magic = lump_reader.read_int(32);
-    let lump_info = cs_demo_parser::parser::lumps::LumpInfo::parse(&mut lump_reader);
-    println!("  Lump magic: 0x{:08x}", magic);
-    println!("  Lump data size: {} bytes", lump_info.data_size);
+    let mut lump_size = 0u64;
+    if filestamp.trim_end_matches('\0') == "PBDEMS2" {
+        let mut lump_file = File::open(&path).expect("Failed to reopen for lumps");
+        lump_file.seek(SeekFrom::Start(1072)).expect("seek lumps");
+        let mut lump_reader = cs_demo_parser::bitreader::BitReader::new_small(lump_file);
+        let magic = lump_reader.read_int(32);
+        let lump_info = cs_demo_parser::parser::lumps::LumpInfo::parse(&mut lump_reader);
+        println!("  Lump magic: 0x{:08x}", magic);
+        println!("  Lump data size: {} bytes", lump_info.data_size);
+        lump_size = lump_info.data_size;
+    } else {
+        println!("  No lump table for this demo format");
+    }
+    if lump_size > 0 {
+        println!("  Lump table size (manual): {} bytes", lump_size);
+    }
 
     // Reset reader for parser
     file.seek(SeekFrom::Start(0)).expect("seek back");


### PR DESCRIPTION
## Summary
- store stack trace in debugging checklist for quick reference
- skip lump parsing in debug_dump for HL2DEMO demos

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`
- `RUST_BACKTRACE=1 cargo run --example debug_dump -- full-demo/2015-08-23-ESLOneCologne2015-fnatic-vs-virtuspro-mirage.dem`

------
https://chatgpt.com/codex/tasks/task_e_686de2fbdf888326818a48bdd1441177