### PR TITLE
Update checklist after failing run

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -3,16 +3,22 @@
 **Latest panic stack trace**
 
 ```
-thread 'main' panicked at src/parser/lumps.rs:21:9: assertion `left == right` failed: unexpected lump table magic
-  left: 10
-  right: 3128995841
+thread 'main' panicked at /workspace/cs-demo-parser-rs/src/bitreader.rs:60:31: called `Result::unwrap()` on an `Err` value: Error { kind: UnexpectedEof, message: "failed to fill whole buffer" }
 stack backtrace:
-   0: __rustc::rust_begin_unwind
-   1: core::panicking::panic_fmt
-   2: core::panicking::assert_failed_inner
-   3: core::panicking::assert_failed
-   4: cs_demo_parser::parser::lumps::LumpInfo::parse
-   5: debug_dump::main
+   0: <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt
+   1: core::fmt::write
+   2: std::io::Write::write_fmt
+   3: std::sys::backtrace::BacktraceLock::print
+   4: std::panicking::default_hook::{{closure}}
+   5: std::panicking::default_hook
+   6: std::panicking::rust_panic_with_hook
+   7: std::panicking::begin_panic_handler::{{closure}}
+   8: std::sys::backtrace::__rust_end_short_backtrace
+   9: __rustc::rust_begin_unwind
+  10: core::panicking::panic_fmt
+  11: core::result::unwrap_failed
+  12: cs_demo_parser::parser::Parser::<R>::parse_to_end
+  13: print_events::main
 ```
 
 The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when reading the demo file. The following checklist outlines investigation steps to resolve the issue.
@@ -39,4 +45,6 @@ The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when read
 - [ ] Review recent commits for changes to `BitReader` or the parser that may have introduced the issue.
 - [ ] Create unit tests for `BitReader::read_int` when reading near EOF to ensure graceful error handling.
 - [ ] Research upstream libraries or documentation (e.g., `demoinfocs-golang`) for known quirks in parsing this specific demo format.
+- Observed `print_events` example failing with `UnexpectedEndOfDemo` after ~74k frames.
+  Need to inspect frame reading logic in `parse_frame_s1` for late-demo cases.
 


### PR DESCRIPTION
## Summary
- document new stack trace from `print_events`
- add note about failure after ~74k frames in debugging checklist

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686dfa036adc832698723d18b247a556