### PR TITLE
Add debug logging around frame parsing

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -39,7 +39,9 @@ The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when read
   - Header parsing no longer consumes signon data, preventing misaligned frame reads.
 - [x] Skip lump parsing in `debug_dump` for HL2DEMO demos to avoid panicking on unexpected magic.
   - Lumps are only present in PBDEMS2 demos. Source 1 demos should ignore the table entirely.
-- [ ] Add logging around `Parser::parse_next_frame` to identify which frame causes the EOF and what command was expected.
+- [x] Add logging around `Parser::parse_next_frame` to identify which frame causes the EOF and what command was expected.
+  - Inserted `println!` calls in `parse_next_frame`, `parse_frame_s1` and
+    `parse_frame_s2` to print the frame index and command type during parsing.
 - [ ] Compare the behaviour with other demo files known to work, to determine if the issue is data specific or systemic.
 - [ ] Consider validating the data after each read in `BitReader` to detect misaligned reads earlier.
 - [ ] Review recent commits for changes to `BitReader` or the parser that may have introduced the issue.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -407,6 +407,8 @@ impl<R: Read> Parser<R> {
             self.signon_skipped = true;
         }
 
+        println!("Starting frame {}", self.current_frame);
+
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             match self
                 .header
@@ -434,6 +436,7 @@ impl<R: Read> Parser<R> {
 
     fn parse_frame_s1(&mut self) -> Result<bool, ParserError> {
         let cmd = self.bit_reader.read_int(8) as u8;
+        println!("  cmd {} on frame {}", cmd, self.current_frame);
         let tick = self.bit_reader.read_signed_int(32);
         self.game_state.set_ingame_tick(tick);
         self.bit_reader.read_int(8); // player slot
@@ -546,6 +549,7 @@ impl<R: Read> Parser<R> {
         let cmd = self.bit_reader.read_varint32();
         let msg_type = cmd & !64;
         let compressed = (cmd & 64) != 0;
+        println!("  msg_type {} on frame {}", msg_type, self.current_frame);
         let tick = self.bit_reader.read_varint32();
         self.game_state.set_ingame_tick(tick as i32);
         let size = self.bit_reader.read_varint32();


### PR DESCRIPTION
## Summary
- log frame number at the start of `parse_next_frame`
- log command values inside `parse_frame_s1` and `parse_frame_s2`
- mark checklist step done

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686dfe5234808326ad7128d4af2cdf7c