### PR TITLE
Fix Source 1 packet parsing

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -40,6 +40,8 @@ The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when read
     the correct format and only parse lumps for PBDEMS2 demos.
 - [x] Remove premature skipping of `signon_length` bytes in `Parser::parse_header` and set `reading_signon` accordingly.
   - Header parsing no longer consumes signon data, preventing misaligned frame reads.
+- [x] Correct packet header bit count in `parse_packet_s1` to 160 bits. The previous
+  multiplication by 8 skipped too much data and caused misaligned reads.
 - [x] Skip lump parsing in `debug_dump` for HL2DEMO demos to avoid panicking on unexpected magic.
   - Lumps are only present in PBDEMS2 demos. Source 1 demos should ignore the table entirely.
 - [x] Add logging around `Parser::parse_next_frame` to identify which frame causes the EOF and what command was expected.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,8 +2,7 @@ use crate::bitreader::BitReader;
 use crate::dispatcher::{Dispatcher, EventDispatcher, HandlerIdentifier};
 use crate::game_state::GameState;
 use crate::sendtables1::TablesParser;
-use crate::sendtables2;
-use crate::stringtables;
+use crate::{sendtables2, stringtables};
 
 pub mod datatable;
 pub mod lumps;
@@ -525,7 +524,11 @@ impl<R: Read> Parser<R> {
     }
 
     fn parse_packet_s1(&mut self) -> Result<(), ParserError> {
-        const HEADER_BITS: u32 = (152 + 4 + 4) * 8;
+        // Net message headers in Source 1 demos are 160 bits (152 bits for the
+        // split packet header plus 4 bits each for flags and view flags). The
+        // previous code multiplied by 8 again which resulted in skipping 160
+        // bytes rather than 160 bits and corrupted the remaining reads.
+        const HEADER_BITS: u32 = 152 + 4 + 4;
         self.bit_reader.skip_bits(HEADER_BITS);
         let size = self.bit_reader.read_signed_int(32) as usize;
 

--- a/src/sendtables/serverclass.rs
+++ b/src/sendtables/serverclass.rs
@@ -125,7 +125,15 @@ impl fmt::Display for ServerClass {
         };
         write!(
             f,
-            "serverClass: id={} name={}\n\tdataTableId={}\n\tdataTableName={}\n\tbaseClasses:\n\t\t{}\n\tproperties:\n\t\t{}",
+            concat!(
+                "serverClass: id={} name={}\n",
+                "\tdataTableId={}\n",
+                "\tdataTableName={}\n",
+                "\tbaseClasses:\n",
+                "\t\t{}\n",
+                "\tproperties:\n",
+                "\t\t{}"
+            ),
             self.id, self.name, self.data_table_id, self.data_table_name, base, props,
         )
     }


### PR DESCRIPTION
## Summary
- correct Source 1 packet header bit count
- format server class string with `concat!`
- note latest panic in debugging checklist

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686e2a8f97708326b3dc512b38a0769a