### PR TITLE
Update debugging checklist

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -63,3 +63,4 @@ Debug notes:
 - Player names are not decoded from events yet, so generating a scoreboard from
   kill events isn't possible. Need to parse `player_info` data or string tables
   in future iterations.
+- Decoding of `CSVCMsg_GameEvent` fields still missing. Kill events contain no player IDs or names, leaving scoreboard empty. Implement descriptor lookup and key parsing in `GameEventHandler` to fill event structs in the next iteration.


### PR DESCRIPTION
## Summary
- add a note about missing CSVCMsg_GameEvent field parsing

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test` *(fails: could not compile `cs-demo-parser` example due to missing fields)*

------
https://chatgpt.com/codex/tasks/task_e_686f5d2655188326b1333183c6fe698d