### PR TITLE
Remove debug output and capture compile error

### DIFF
--- a/debugging_checklist.md
+++ b/debugging_checklist.md
@@ -25,7 +25,21 @@ stack backtrace:
   16: core::ops::function::FnOnce::call_once
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
 ```
-Compile error trying to add scoreboard: `Player` struct has no `name` field, see `error[E0609]`.
+Latest compile error when trying to use player names in `collect_kills`:
+
+```
+error[E0609]: no field `name` on type `&cs_demo_parser::events::Player`
+ --> examples/collect_kills.rs:41:57
+  |
+41 |                     let entry = scoreboard.entry(killer.name.clone()).or_insert((0, 0));
+   |                                                         ^^^^ unknown field
+
+error[E0609]: no field `name` on type `&cs_demo_parser::events::Player`
+ --> examples/collect_kills.rs:45:57
+  |
+45 |                     let entry = scoreboard.entry(victim.name.clone()).or_insert((0, 0));
+   |                                                         ^^^^ unknown field
+```
 
 The `debug_dump` example panics with `UnexpectedEof` in `bitreader.rs` when reading the demo file. The following checklist outlines investigation steps to resolve the issue.
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -399,8 +399,6 @@ impl<R: Read> Parser<R> {
             self.signon_skipped = true;
         }
 
-        println!("Starting frame {}", self.current_frame);
-
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             match self
                 .header
@@ -428,7 +426,6 @@ impl<R: Read> Parser<R> {
 
     fn parse_frame_s1(&mut self) -> Result<bool, ParserError> {
         let cmd = self.bit_reader.read_int(8) as u8;
-        println!("  cmd {} on frame {}", cmd, self.current_frame);
         let tick = self.bit_reader.read_signed_int(32);
         self.game_state.set_ingame_tick(tick);
         self.bit_reader.read_int(8); // player slot
@@ -572,7 +569,7 @@ impl<R: Read> Parser<R> {
         let cmd = self.bit_reader.read_varint32();
         let msg_type = cmd & !64;
         let compressed = (cmd & 64) != 0;
-        println!("  msg_type {} on frame {}", msg_type, self.current_frame);
+
         let tick = self.bit_reader.read_varint32();
         self.game_state.set_ingame_tick(tick as i32);
         let size = self.bit_reader.read_varint32();


### PR DESCRIPTION
## Summary
- remove leftover debugging prints from the parser
- note latest compile failure in `debugging_checklist.md`

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686f6966303883268165d0ed731db054