### PR TITLE
Implement server class parsing

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -463,9 +463,6 @@ impl<R: Read> Parser<R> {
                     data.push(self.bit_reader.read_int(8) as u8);
                 }
 
-                let _ = self.s1_tables.parse_packet(&data);
-                self.dispatch_event(crate::events::DataTablesParsed);
-
                 if self.s1_tables.parse_packet(&data).is_ok() {
                     self.server_classes = self.s1_tables.server_classes().to_vec();
                     self.update_equipment_mapping_from_classes();
@@ -767,6 +764,7 @@ impl<R: Read> Parser<R> {
                 },
                 | proto_msg::SvcMessages::SvcClassInfo => {
                     if let Ok(msg) = proto_msg::CsvcMsgClassInfo::decode(buf) {
+                        self.s2_tables.on_class_info(&msg);
                         self.dispatch_net_message(msg);
                     }
                 },

--- a/tasks/entity_population_tasks.md
+++ b/tasks/entity_population_tasks.md
@@ -3,7 +3,7 @@
 This file tracks progress on the items listed in `entity_population_checklist.md`.
 Check off tasks as implementations are completed.
 
-- [ ] Parse server classes from `svc_ServerInfo` and datatable messages so entity definitions are available before frames are processed.
+- [x] Parse server classes from `svc_ServerInfo` and datatable messages so entity definitions are available before frames are processed.
 - [ ] Decode string tables, especially `userinfo` and item definition tables, to obtain player names and equipment mapping.
 - [ ] Populate `GameState.players_by_user_id` and `players_by_entity_id` whenever `player_connect` or entity creation events are seen.
 - [ ] Update `Player` fields such as `steam_id64`, `name`, `team`, and `entity_id` from the parsed data.


### PR DESCRIPTION
## Summary
- parse Source2 class info messages to register server classes
- avoid duplicate parsing of Source1 datatables
- mark server class parsing task complete

## Testing
- `cargo fmt -- --check`
- `cargo clippy` *(fails: `cargo-clippy` not installed)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fbd14f7448326aa6c9fa173e89ae1