### PR TITLE
Add basic player population from userinfo

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -513,6 +513,12 @@ impl<R: Read> Parser<R> {
     fn parse_stringtable_packet(&mut self, data: &[u8]) {
         let updates = self.string_tables.parse_packet(data);
         for t in updates {
+            if t.name.eq_ignore_ascii_case("userinfo") {
+                self.game_state_mut().apply_userinfo_table(&t);
+            }
+            if t.name == "ItemDefinitions" {
+                self.update_equipment_mapping_from_classes();
+            }
             self.dispatch_event(StringTableUpdated { table: t });
         }
     }
@@ -779,6 +785,12 @@ impl<R: Read> Parser<R> {
                             self.dispatch_event(crate::events::StringTableCreated {
                                 table_name: t.name.clone(),
                             });
+                            if t.name.eq_ignore_ascii_case("userinfo") {
+                                self.game_state_mut().apply_userinfo_table(&t);
+                            }
+                            if t.name == "ItemDefinitions" {
+                                self.update_equipment_mapping_from_classes();
+                            }
                             self.dispatch_event(StringTableUpdated { table: t });
                         }
                         self.dispatch_net_message(msg);
@@ -787,6 +799,12 @@ impl<R: Read> Parser<R> {
                 | proto_msg::SvcMessages::SvcUpdateStringTable => {
                     if let Ok(msg) = proto_msg::CsvcMsgUpdateStringTable::decode(buf) {
                         if let Some(t) = self.string_tables.on_update_string_table(&msg) {
+                            if t.name.eq_ignore_ascii_case("userinfo") {
+                                self.game_state_mut().apply_userinfo_table(&t);
+                            }
+                            if t.name == "ItemDefinitions" {
+                                self.update_equipment_mapping_from_classes();
+                            }
                             self.dispatch_event(StringTableUpdated { table: t });
                         }
                         self.dispatch_net_message(msg);

--- a/tests/player_population.rs
+++ b/tests/player_population.rs
@@ -1,0 +1,35 @@
+use cs_demo_parser::game_state::GameState;
+use cs_demo_parser::proto::msgs2::CMsgPlayerInfo;
+use cs_demo_parser::stringtables::{StringTable, StringTableEntry};
+use prost::Message;
+
+#[test]
+fn userinfo_updates_players() {
+    let mut gs = GameState::default();
+    let mut tbl = StringTable {
+        name: "userinfo".into(),
+        ..Default::default()
+    };
+    let mut info = CMsgPlayerInfo::default();
+    info.name = Some("Alice".into());
+    info.userid = Some(1);
+    info.xuid = Some(42);
+    let mut buf = Vec::new();
+    info.encode(&mut buf).unwrap();
+    tbl.entries.insert(
+        1,
+        StringTableEntry {
+            value: String::new(),
+            user_data: buf,
+        },
+    );
+
+    gs.apply_userinfo_table(&tbl);
+
+    assert_eq!(1, gs.players_by_user_id.len());
+    let p = gs.players_by_user_id.get(&1).unwrap();
+    assert_eq!("Alice", p.name);
+    assert_eq!(1, p.user_id);
+    assert_eq!(42, p.steam_id64);
+    assert!(p.is_connected);
+}


### PR DESCRIPTION
## Summary
- parse `userinfo` string table updates and populate players
- update equipment mapping when item definition string table changes
- track player entities on creation
- add tests for userinfo table processing

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fc0b85ebc832680f429f81b514fc0