### PR TITLE
Add weapon entity tracking

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -327,6 +327,14 @@ impl GameState {
             self.dropped_weapons
                 .entry(ent.index)
                 .or_insert_with(|| name.to_string());
+        } else if let Some(eq) = self.equipment_mapping.get(name) {
+            self.weapons.entry(ent.index).or_insert_with(|| Equipment {
+                equipment_type: *eq,
+                entity: None,
+                original_string: name.to_string(),
+                unique_id: ent.index as i64,
+                position: Default::default(),
+            });
         } else if name.contains("GameRules") {
             self.rules.entity = Some(ent.clone());
         }
@@ -355,6 +363,7 @@ impl GameState {
             use crate::sendtables::EntityOp;
             if ev.op.contains(EntityOp::DELETED) {
                 self.remove_entity(ev.entity.index);
+                self.weapons.remove(&ev.entity.index);
                 self.projectile_owners.remove(&ev.entity.index);
                 self.dropped_weapons.remove(&ev.entity.index);
                 self.grenade_projectiles.remove(&ev.entity.index);

--- a/tests/entity_population.rs
+++ b/tests/entity_population.rs
@@ -1,0 +1,38 @@
+use cs_demo_parser::common::{EquipmentType, Player};
+use cs_demo_parser::game_state::GameState;
+use cs_demo_parser::parser::EntityEvent;
+use cs_demo_parser::sendtables::EntityOp;
+use cs_demo_parser::sendtables2::{Class, Entity};
+
+#[test]
+fn weapon_entities_are_tracked() {
+    let mut gs = GameState::default();
+    gs.equipment_mapping
+        .insert("CWeaponAK47".into(), EquipmentType::Ak47);
+    let class = Class {
+        class_id: 1,
+        name: "CWeaponAK47".into(),
+        serializer: None,
+    };
+    let ent = Entity {
+        index: 10,
+        serial: 1,
+        class,
+    };
+
+    gs.handle_event(&EntityEvent {
+        entity: ent.clone(),
+        op: EntityOp::CREATED,
+    });
+    assert_eq!(1, gs.weapons.len());
+    assert_eq!(
+        EquipmentType::Ak47,
+        gs.weapons.get(&10).unwrap().equipment_type
+    );
+
+    gs.handle_event(&EntityEvent {
+        entity: ent,
+        op: EntityOp::DELETED,
+    });
+    assert!(gs.weapons.is_empty());
+}


### PR DESCRIPTION
## Summary
- track weapon entities in game state
- cover weapon handling with a new unit test

## Testing
- `cargo fmt`
- `cargo clippy -q`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc8c761f08326a37c77ce14e4386c