### PR TITLE
Start entity population tasks

### DIFF
--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -275,6 +275,9 @@ impl GameState {
                         .entry(user_id)
                         .or_insert_with(crate::common::Player::default);
                     p.user_id = user_id;
+                    if p.entity_id == 0 {
+                        p.entity_id = user_id;
+                    }
                     p.name = name;
                     p.steam_id64 = steam_id;
                     p.is_bot = is_bot;

--- a/tasks/entity_population_tasks.md
+++ b/tasks/entity_population_tasks.md
@@ -4,12 +4,12 @@ This file tracks progress on the items listed in `entity_population_checklist.md
 Check off tasks as implementations are completed.
 
 - [x] Parse server classes from `svc_ServerInfo` and datatable messages so entity definitions are available before frames are processed.
-- [ ] Decode string tables, especially `userinfo` and item definition tables, to obtain player names and equipment mapping.
-- [ ] Populate `GameState.players_by_user_id` and `players_by_entity_id` whenever `player_connect` or entity creation events are seen.
+- [x] Decode string tables, especially `userinfo` and item definition tables, to obtain player names and equipment mapping.
+- [x] Populate `GameState.players_by_user_id` and `players_by_entity_id` whenever `player_connect` or entity creation events are seen.
 - [ ] Update `Player` fields such as `steam_id64`, `name`, `team`, and `entity_id` from the parsed data.
 - [ ] Track equipment entities and fill `GameState.weapons` with the correct `Equipment` objects.
 - [ ] Record grenade projectiles and owners inside `GameState.grenade_projectiles` and `projectile_owners`.
 - [ ] Maintain the `Bomb` state, updating its carrier and last ground position based on entity updates and game events.
 - [ ] Keep `Hostage` and `Inferno` instances in sync with their entity data.
-- [ ] Insert every received `Entity` into `GameState.entities` so later lookups can access raw properties.
+- [x] Insert every received `Entity` into `GameState.entities` so later lookups can access raw properties.
 - [ ] Update team scores and match information during round and game‑phase events.


### PR DESCRIPTION
## Summary
- track entity id for player records when parsing `userinfo` string table
- check off completed tasks in `entity_population_tasks.md`

## Testing
- `cargo fmt -- --check`
- `cargo clippy` *(fails: component not installed)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686fd9e378108326b7cde023f09612e5