### PR TITLE
Update collect_kills example to display player names

### DIFF
--- a/examples/collect_kills.rs
+++ b/examples/collect_kills.rs
@@ -24,10 +24,6 @@ fn key_to_i32(key: &csvc_msg_game_event::KeyT) -> i32 {
     key.val_long.or(key.val_short).or(key.val_byte).unwrap_or(0)
 }
 
-fn key_to_string(key: &csvc_msg_game_event::KeyT) -> String {
-    key.val_string.clone().unwrap_or_default()
-}
-
 fn main() {
     let path = demo_path_from_args();
     let file = File::open(&path).expect("failed to open demo");
@@ -64,10 +60,8 @@ fn main() {
     });
 
     let scoreboard: std::sync::Arc<std::sync::Mutex<HashMap<i32, (u32, u32)>>> = Default::default();
-    let names: std::sync::Arc<std::sync::Mutex<HashMap<i32, String>>> = Default::default();
     let desc_clone = descriptors.clone();
     let sb_clone = scoreboard.clone();
-    let names_clone = names.clone();
     parser.register_net_message_handler::<CsvcMsgGameEvent, _>(move |ev| {
         let map = desc_clone.lock().unwrap();
         let desc = match ev.eventid.and_then(|id| map.get(&id)) {
@@ -75,20 +69,6 @@ fn main() {
             | None => return,
         };
         match desc.name.as_str() {
-            | "player_connect" | "player_connect_full" => {
-                let mut userid = 0;
-                let mut name = String::new();
-                for ((kname, _), key) in desc.keys.iter().zip(&ev.keys) {
-                    match kname.as_str() {
-                        | "userid" => userid = key_to_i32(key),
-                        | "name" => name = key_to_string(key),
-                        | _ => {},
-                    }
-                }
-                if userid != 0 && !name.is_empty() {
-                    names_clone.lock().unwrap().insert(userid, name);
-                }
-            },
             | "player_death" => {
                 let mut victim = 0;
                 let mut attacker = 0;
@@ -116,12 +96,14 @@ fn main() {
     }
 
     let sb = scoreboard.lock().unwrap();
-    let name_map = names.lock().unwrap();
+    let gs = parser.game_state();
     println!("scoreboard:");
     for (id, (k, d)) in sb.iter() {
-        let name = name_map
+        let name = gs
+            .participants()
+            .by_user_id()
             .get(id)
-            .cloned()
+            .map(|p| p.name.clone())
             .unwrap_or_else(|| format!("#{}", id));
         println!("{}: {} kills / {} deaths", name, k, d);
     }


### PR DESCRIPTION
## Summary
- update the collect_kills example to use player names from the populated game state

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686ff65f2a9883269f9e395f3653a212