### PR TITLE
Fix userinfo mapping for collect_kills

### DIFF
--- a/examples/collect_kills.rs
+++ b/examples/collect_kills.rs
@@ -73,7 +73,8 @@ fn main() {
                 if !entry.user_data.is_empty() {
                     if let Ok(info) = CMsgPlayerInfo::decode(&entry.user_data[..]) {
                         if let Some(name) = info.name {
-                            names_clone2.lock().unwrap().insert(*idx, name);
+                            let user_id = info.userid.unwrap_or(*idx);
+                            names_clone2.lock().unwrap().insert(user_id, name);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- fix nickname lookup in collect_kills example by using user IDs

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `DEMOINFOCS_SKIP_DEMOS=1 cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6870d38ce5188326bfde2824dfb3e669