### PR TITLE
Add collect_kills example tasks checklist

### DIFF
--- a/tasks/collect_kills_names_tasks.md
+++ b/tasks/collect_kills_names_tasks.md
@@ -1,0 +1,9 @@
+# Collect Kills Example Tasks
+
+The following checklist tracks remaining work to display player nicknames in the `collect_kills` example.
+
+- [ ] Ensure the demo's `userinfo` string table is parsed so player names map to user IDs.
+- [ ] Verify the parser handles Source 1 string tables, updating the simple implementation if needed.
+- [ ] After names populate `GameState`, modify `collect_kills.rs` to show them in kill logs and the scoreboard.
+- [ ] Add debug logging to trace parsing and confirm names are available.
+- [ ] Re-run `collect_kills` until the output lists `Flusha: 20 kills`.


### PR DESCRIPTION
## Summary
- document tasks needed to show player names for `collect_kills`

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6870dfd87ba0832699299123861a9138